### PR TITLE
Update dockerfile and docs.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,4 @@
-# Jupyter notebook dockers are arch specfic. 
-# Uncomment the one for your architecture and comment out the other
+FROM jupyter/scipy-notebook:latest
 
-# Base image for aarch64
-FROM jupyter/scipy-notebook:aarch64-python-3.10.5
-
-# Base image for x86_64
-# FROM jupyter/scipy-notebook:latest
-
-RUN pip3 install git+https://github.com/jpwhite4/xdmod-python.git
+RUN pip3 install git+https://github.com/ubccr/xdmod-python.git
+RUN pip3 install plotly

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,10 @@
 # Instructions
 
-As of July 2022 there are seperate docker images for ARM and x86 systems. If you are running an
-x86 system then edit the Dockerfile and change the `FROM` line as per the inline comments
-in the file.
+This directory contains a configuration file to build a
+docker image containing Jupyter notebooks and the python-based XDMoD
+interface library.
 
-Then build the docker as follows:
+Build the docker image as follows:
 ```sh
 docker build -t xdmodnotebooks .
 ```


### PR DESCRIPTION
Update the dockerfile to point to the ubccr repo (which is now the offical source).

Also the jupyter project has now started building multi-architecture docker images, so I've also updated the dockerfile and README to reflect this.