### PR TITLE
Add raw data example.

### DIFF
--- a/XDMoD-Data-Raw-Data-Example.ipynb
+++ b/XDMoD-Data-Raw-Data-Example.ipynb
@@ -26,6 +26,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8a5b9785-aeab-4114-a75c-62f2a5d7b946",
+   "metadata": {},
+   "source": [
+    "## Install/upgrade the required modules\n",
+    "Run the code below to install/upgrade the modules needed to run this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b108c69-4af9-4677-8131-403645aa7a9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "! {sys.executable} -m pip install --upgrade xdmod-data python-dotenv tabulate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3be64d2-5140-4eea-a3f6-bf9f594107af",
+   "metadata": {},
+   "source": [
+    "If running that code caused a new version of Plotly to be installed/upgraded, you may need to refresh your browser window for plots to appear correctly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f1198bdc-eebf-4b9d-b432-ac32ecc3befb",
    "metadata": {
     "tags": []


### PR DESCRIPTION
This adds an example notebook showing how to use the `get_raw_data()` method. This example is planned to be shown during the PEARC23 tutorial after the first example.