### PR TITLE
Remove documentation about spaces in env file.

### DIFF
--- a/XDMoD-Data-First-Example.ipynb
+++ b/XDMoD-Data-First-Example.ipynb
@@ -180,7 +180,7 @@
    "metadata": {},
    "source": [
     "## Store your API token in the environment file\n",
-    "Open the `xdmod-data.env` file and paste your token after `XDMOD_API_TOKEN=`. Make sure there are no spaces before or after the equals sign.\n",
+    "Open the `xdmod-data.env` file and paste your token after `XDMOD_API_TOKEN=`.\n",
     "\n",
     "Save the file."
    ]

--- a/XDMoD-Data-Machine-Learning-Example.ipynb
+++ b/XDMoD-Data-Machine-Learning-Example.ipynb
@@ -167,7 +167,7 @@
    "metadata": {},
    "source": [
     "## Store your API token in the environment file\n",
-    "Open the `xdmod-data.env` file and paste your token after `XDMOD_API_TOKEN=`. Make sure there are no spaces before or after the equals sign.\n",
+    "Open the `xdmod-data.env` file and paste your token after `XDMOD_API_TOKEN=`.\n",
     "\n",
     "Save the file."
    ]

--- a/XDMoD-Data-Raw-Data-Example.ipynb
+++ b/XDMoD-Data-Raw-Data-Example.ipynb
@@ -180,7 +180,7 @@
    "metadata": {},
    "source": [
     "## Store your API token in the environment file\n",
-    "Open the `xdmod-data.env` file and paste your token after `XDMOD_API_TOKEN=`. Make sure there are no spaces before or after the equals sign.\n",
+    "Open the `xdmod-data.env` file and paste your token after `XDMOD_API_TOKEN=`.\n",
     "\n",
     "Save the file."
    ]


### PR DESCRIPTION
This removes the line from the documentation about the environment file, "Make sure there are no spaces before or after the equals sign," since spaces actually do not have an effect; the API token is still loaded properly into the environment.