### PR TITLE
Instruct `pip` only to upgrade to minor and patch versions of `xdmod-data`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # xdmod-notebooks Changelog
 
 ## Main development branch
+- Instruct `pip` only to upgrade to minor and patch versions of `xdmod-data` ([\#21](https://github.com/ubccr/xdmod-notebooks/pull/21)).
 - Mention in intro notebook that aggregate data is returned as a Pandas Series ([\#20](https://github.com/ubccr/xdmod-notebooks/pull/20)).
 - Add Changelog ([\#19](https://github.com/ubccr/xdmod-notebooks/pull/19)).
 - Update README to account for different release versions ([\#17](https://github.com/ubccr/xdmod-notebooks/pull/17)).

--- a/XDMoD-Data-First-Example.ipynb
+++ b/XDMoD-Data-First-Example.ipynb
@@ -41,7 +41,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "! {sys.executable} -m pip install --upgrade xdmod-data python-dotenv tabulate"
+    "! {sys.executable} -m pip install --upgrade 'xdmod-data>=1.0.0,<2.0.0' python-dotenv tabulate"
    ]
   },
   {

--- a/XDMoD-Data-Machine-Learning-Example.ipynb
+++ b/XDMoD-Data-Machine-Learning-Example.ipynb
@@ -39,7 +39,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "! {sys.executable} -m pip install --upgrade xdmod-data python-dotenv tabulate"
+    "! {sys.executable} -m pip install --upgrade 'xdmod-data>=1.0.0,<2.0.0' python-dotenv tabulate"
    ]
   },
   {

--- a/XDMoD-Data-Raw-Data-Example.ipynb
+++ b/XDMoD-Data-Raw-Data-Example.ipynb
@@ -41,7 +41,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "! {sys.executable} -m pip install --upgrade xdmod-data python-dotenv tabulate"
+    "! {sys.executable} -m pip install --upgrade 'xdmod-data>=1.0.0,<2.0.0' python-dotenv tabulate"
    ]
   },
   {


### PR DESCRIPTION
This PR updates the code cells in the example notebooks that install `xdmod-data` only to upgrade `xdmod-data` to minor and patch versions (which are backwards compatible). This way, if a major version (which is not backwards compatible) is released, running the notebooks will not upgrade to that version, since doing so could cause the notebooks to stop working.