### PR TITLE
Update changelog, R upgrade instructions, and R code style.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Instruct `pip` only to upgrade to minor and patch versions of `xdmod-data` ([\#21](https://github.com/ubccr/xdmod-notebooks/pull/21)).
 - Order changelog by merge date ascending ([\#26](https://github.com/ubccr/xdmod-notebooks/pull/26)).
 - Add a "Feedback / Feature Requests" section to the README ([\#24](https://github.com/ubccr/xdmod-notebooks/pull/24)).
+- Add example R Markdown file ([\#27](https://github.com/ubccr/xdmod-notebooks/pull/27)).
+- Update changelog, R upgrade instructions, and R code style ([\#29](https://github.com/ubccr/xdmod-notebooks/pull/29)).
 
 ## v1.0.0 (2023-07-21)
 - Initial release.

--- a/R/README.md
+++ b/R/README.md
@@ -1,10 +1,7 @@
 # xdmod-notebooks R example
-This directory contains an example R Markdown file demonstrating how to use the XDMoD Data Analytics Framework via the [`xdmod-data` package](https://pypi.org/project/xdmod-data/).
+This directory contains an example R Markdown file demonstrating how to use the XDMoD Data Analytics Framework via the [`xdmod-data`](https://pypi.org/project/xdmod-data/) package.
 
 For examples using Python in Jupyter instead, see the main [README](../).
-
-## Download
-The latest version of this `xdmod-notebooks` repository can be downloaded from the [releases page](https://github.com/ubccr/xdmod-notebooks/releases) — under "Assets," click one of the "Source code" links.
 
 ## Setup
 Follow the instructions below to set up your system to run the R Markdown file in RStudio Desktop using an Anaconda environment.
@@ -19,13 +16,13 @@ Install the following R libraries in RStudio Desktop (`Tools` > `Install Package
 
 Install Anaconda following [these instructions](https://docs.anaconda.com/free/anaconda/install/index.html).
 
-Next an Anaconda environment for `xdmod-notebooks` should be created and the `xdmod-data` package should be installed. Command line instructions for doing so are below.
+Next an Anaconda environment for `xdmod-notebooks` should be created and the latest version of the `xdmod-data` package should be installed. Command line instructions for doing so are below. Note that the last two commands can also be run to apply any minor or patch upgrades to the package.
 
 ```
 conda activate
 conda create -y -n xdmod-notebooks python
 conda activate xdmod-notebooks
-python3 -m pip install 'xdmod-data>=1.0.0,<2.0.0'
+python3 -m pip install --upgrade 'xdmod-data>=1.0.0,<2.0.0'
 ```
 
 ### Obtain and store an API token
@@ -37,7 +34,7 @@ XDMOD_API_TOKEN=<TOKEN>
 ```
 
 ## Usage
-* In RStudio Desktop, open and run the R Markdown file (`XDMoD-Data-First-Example-with-R-and-Reticulate.Rmd`) from your downloaded copy of this repository. If you are not familiar with running R Markdown files, the "Help" tab may provide useful information.
+* In RStudio Desktop, open and run the R Markdown file (`XDMoD-Data-First-Example-with-R-and-Reticulate.Rmd`). If you are not familiar with running R Markdown files, the "Help" tab may provide useful information.
 
 ## Feedback / Feature Requests, Support, Contributing, License, and Reference
 See the main [README](../).

--- a/R/XDMoD-Data-First-Example-with-R-and-Reticulate.Rmd
+++ b/R/XDMoD-Data-First-Example-with-R-and-Reticulate.Rmd
@@ -3,7 +3,7 @@ title: "XDMoD Data Analytics Framework — First Example with R and Reticulate"
 output:
   html_document:
     toc: true
-    toc_depth: '4'
+    toc_depth: 4
     df_print: paged
   pdf_document:
     df_print: kable
@@ -37,7 +37,7 @@ FutureWarning: Index.format is deprecated and will be removed in a future versio
 
 ## Load the required R libraries
 
-```{r setup, results='hide',message=FALSE,warning=FALSE}
+```{r setup, results = "hide", message = FALSE, warning = FALSE}
 library(dotenv)
 library(knitr)
 library(plotly)
@@ -93,9 +93,9 @@ with(dw, {
 
 ```{r}
 df <- data %>%
-  rownames_to_column(var="Time") %>% # Move row names to column
+  rownames_to_column(var = "Time") %>% # Move row names to column
   tibble() %>% # User newer data.frame
-  mutate(Time=ymd(Time)) # Convert character to date
+  mutate(Time = ymd(Time)) # Convert character to date
 ```
 
 ## Show tabular data
@@ -107,8 +107,8 @@ df
 ## Plot the data
 
 ```{r}
-ggplot(df, aes(x=Time,y=`Number of Users: Active`)) +
-    geom_line() + geom_point()
+ggplot(df, aes(x = Time, y = `Number of Users: Active`)) +
+  geom_line() + geom_point()
 ```
 
 ## Do further data processing
@@ -119,16 +119,19 @@ Run the code below to add a column for the day of the week:
 
 ```{r}
 df$`Day Name` <- factor(
-    weekdays(df$Time), 
-    levels=c("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", 
-             "Saturday", "Sunday"))
+  weekdays(df$Time),
+  levels = c(
+    "Monday", "Tuesday", "Wednesday", "Thursday", "Friday",
+    "Saturday", "Sunday"
+  )
+)
 df
 ```
 
 Run the code below to show a box plot of the data grouped by day of the week:
 
 ```{r}
-ggplot(df, aes(x=`Day Name`,y=`Number of Users: Active`)) + geom_boxplot()
+ggplot(df, aes(x = `Day Name`, y = `Number of Users: Active`)) + geom_boxplot()
 ```
 
 # Details of the `get_data()` method
@@ -137,7 +140,7 @@ Now that you have seen a basic example of using the `get_data()` method, read be
 
 ## Wrap data warehouse calls in a runtime context
 
-XDMoD data is accessed over a network connection, which involves establishing connections and creating temporary resources. To ensure these connections and resources are cleaned up properly in spite of any runtime errors, you should call data warehouse methods within a **runtime context** by using the `with` statement in `Python` to wrap the execution of XDMoD queries, store the result, and execute any long running calculations outside of the runtime context, as in the template below. `Reticulate` in R tries to mimic such behaiviour with R `with` function. 
+XDMoD data is accessed over a network connection, which involves establishing connections and creating temporary resources. To ensure these connections and resources are cleaned up properly in spite of any runtime errors, you should call data warehouse methods within a **runtime context** by using the Reticulate `with` function to wrap the execution of XDMoD queries, store the result, and execute any long running calculations outside of the runtime context, as in the template below. The Reticulate `with` function mimics the Python `with` statement.
 
 ```{r}
 with(dw, {
@@ -172,7 +175,7 @@ As already seen, you can specify the duration as start and end times:
 
 ```{r}
 with(dw, {
-  data <- dw$get_data(duration = c('2023-01-01', '2023-04-30'))
+  data <- dw$get_data(duration = c("2023-01-01", "2023-04-30"))
 })
 ```
 
@@ -180,7 +183,7 @@ You can instead specify the duration using a special string value; a list of the
 
 ```{r}
 with(dw, {
-  durations = dw$get_durations()
+  durations <- dw$get_durations()
 })
 unlist(durations)
 ```
@@ -191,7 +194,7 @@ A **realm** is a category of data in the XDMoD data warehouse. You can use the `
 
 ```{r}
 with(dw, {
-  realms = dw$describe_realms()
+  realms <- dw$describe_realms()
 })
 realms
 ```
@@ -202,18 +205,19 @@ A **metric** is a statistic for which data exists in a given realm. You can use 
 
 ```{r}
 with(dw, {
-  metrics = dw$describe_metrics("Jobs")
+  metrics <- dw$describe_metrics("Jobs")
 })
-metrics %>% knitr::kable(format="html")
+metrics %>% knitr::kable(format = "html")
 ```
 
 ## Dimension
 A **dimension** is a grouping of data. You can use the `describe_dimensions(realm)` method to get a data frame containing the list of valid dimensions in the given realm. The realm must be passed in as a string.
 
 ```{r}
-with(dw,{
-    dimensions <- dw$describe_dimensions("Jobs") })
-dimensions %>% knitr::kable(format="html")
+with(dw, {
+  dimensions <- dw$describe_dimensions("Jobs")
+})
+dimensions %>% knitr::kable(format = "html")
 ```
 
 ## Pass in realms, metrics, and dimensions using labels or IDs
@@ -237,7 +241,10 @@ with(dw, {
 
 ```{r}
 with(dw, {
-  filter_values <- dw$get_filter_values("Jobs", "Resource") # "resource" also works
+  filter_values <- dw$get_filter_values(
+    "Jobs",
+    "Resource" # "resource" also works
+  )
 })
 filter_values
 ```
@@ -245,7 +252,7 @@ filter_values
 For methods in the API that take filters as arguments, you must specify the filters as a dictionary in which the keys are dimensions (labels or IDs) and the values are string filter values (labels or IDs) or sequences of string filter values. For example, to return only data for which the field of science is biophysics and the resource is either NCSA Delta GPU or TACC Stampede2:
 
 ```{r}
-with(dw,{
+with(dw, {
   data <- dw$get_data(
     filters = list(
       "Field of Science" = "Biophysics", # "fieldofscience" = "246" also works
@@ -273,7 +280,7 @@ with(dw, {
 The **aggregation unit** specifies how data is aggregated by time. You can get a list of valid aggregation units by calling the `get_aggregation_units()` method.
 
 ```{r}
-with(dw,{
+with(dw, {
   aggregation_units <- dw$get_aggregation_units()
 })
 unlist(aggregation_units)


### PR DESCRIPTION
This PR does a bit of cleanup of https://github.com/ubccr/xdmod-notebooks/pull/27:
* Add entries to the changelog for that PR and this one.
* Remove the `Download` section from `R/README.md` since the R Markdown file has not yet been released in a GitHub source code asset.
* Add instructions in `R/README.md` for upgrading `xdmod-data` to minor and patch versions.
* Make some of the code style in the R Markdown file more consistent and follow the Tidyverse style (I used `lintr` to check).