### PR TITLE
Adding JupyterHub Notebooks for v2.0

### DIFF
--- a/XDMoD-Data-First-Example-JupyterHub.ipynb
+++ b/XDMoD-Data-First-Example-JupyterHub.ipynb
@@ -1,0 +1,630 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "db4061c7-2b36-4284-af31-4ae940a07768",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# XDMoD Data Analytics Framework — First Example for JupyterHub\n",
+    "\n",
+    "Notebook v1.1.0 (2025-07-14)\n",
+    "\n",
+    "Compatible with XDMoD Data Analytics Framework v≥1.0.0 and <2.0.0\n",
+    "\n",
+    "© 2023–2024 University at Buffalo Center for Computational Research\n",
+    "\n",
+    "See the [xdmod-notebooks](https://github.com/ubccr/xdmod-notebooks) repository for information on setup, support, contributing, licensing, and referencing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77f9e969-5120-4a7a-a844-fa6fda893755",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "The XDMoD Data Analytics Framework provides API access to the data in XDMoD via the [`xdmod_data` Python module](https://pypi.org/project/xdmod-data). This notebook provides an introductory example showing how to use the module. You will use the XDMoD API to request data, load them into a [Pandas](https://pandas.pydata.org/) [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html), and generate plots. The dataset in this example contains the number of active users of [ACCESS](https://access-ci.org/)-allocated resources per day of the week over a 4-month period."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdc4dfd8-5e8c-407c-ace6-f484608e4141",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Configure notebook formatting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb20fc44-df65-4d32-9040-2a13ba1ac5c1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exceptions\n",
+    "\n",
+    "Run the code below to simplify how Python exceptions are displayed in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "852da6ec-8c06-4389-88ae-48c24acb621e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "def exception_handler(exception_type, exception, traceback):\n",
+    "    print(\"%s: %s\" % (exception_type.__name__, exception), file=sys.stderr)\n",
+    "get_ipython()._showtraceback = exception_handler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7242d35a-7d1b-4b14-9aa5-b4a9bcb10a91",
+   "metadata": {},
+   "source": [
+    "### Tables\n",
+    "\n",
+    "Run the code below to set up for displaying Pandas DataFrames as Markdown tables in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2678201f-feba-4b2a-897f-284f05119b9c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, Markdown\n",
+    "def display_df_md_table(df):\n",
+    "    return display(Markdown(df.replace('\\n', '<br/>', regex=True).to_markdown()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d588361-779e-42dc-ade7-6c95f3900c95",
+   "metadata": {},
+   "source": [
+    "### Plots\n",
+    "\n",
+    "Run the code below to set up the external Plotly library to make plots using a custom XDMoD theme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c6c5409-db04-4d29-a9eb-fc0935322e80",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "import plotly.io as pio\n",
+    "import xdmod_data.themes\n",
+    "pio.templates.default = \"timeseries\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc6c166c-5e03-403b-88e1-4b4b2735c690",
+   "metadata": {},
+   "source": [
+    "## Initialize the XDMoD Data Warehouse\n",
+    "\n",
+    "Run the code below to prepare for getting data from the XDMoD data warehouse at the given URL. If no host is specified, the XDMOD_HOST environment variable is used to determine the host."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57583c14-0196-4e1d-bc63-3a66c493fa44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from xdmod_data.warehouse import DataWarehouse\n",
+    "dw = DataWarehouse()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3738a176-5b11-4a27-bf5c-2e785f07210d",
+   "metadata": {},
+   "source": [
+    "## Get the data\n",
+    "\n",
+    "Run the code below to use the `get_data()` method to request data from XDMoD and load them into a Pandas DataFrame. This example gets the number of active users of ACCESS-allocated resources over a 4-month period. Each of the parameters of the method will be explained later in this notebook. Use `with` to create a runtime context; this is also explained later in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00e141b1-3554-44e6-a08b-85b3f6b19fd3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_data(\n",
+    "        duration=('2023-01-01', '2023-04-30'),\n",
+    "        realm='Jobs',\n",
+    "        metric='Number of Users: Active',\n",
+    "    )\n",
+    "display(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "258e366e-04fb-4a99-b1cf-31dc07bfc676",
+   "metadata": {},
+   "source": [
+    "Note that the `data` object is a Pandas DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d89714ef-272b-4b39-a921-a4158dce8805",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe649112-1a6b-4869-9201-8d340597eaa9",
+   "metadata": {},
+   "source": [
+    "## Plot the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "498b75e8-7a73-4c77-966e-71844ad48b5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = px.line(data, y='Number of Users: Active')\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "847a0a67-b6ce-44dd-aa67-bac7ba1cd126",
+   "metadata": {},
+   "source": [
+    "## Do further data processing\n",
+    "\n",
+    "You can do further processing on the DataFrame to produce analysis and plots beyond those that are available in the XDMoD portal.\n",
+    "\n",
+    "Run the code below to add a column for the day of the week:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c73680d5-7df1-4e97-88cc-92deaa9f3697",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data['Day Name'] = data.index.strftime('%a')\n",
+    "display(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78006e89-7b42-4263-8a45-d2491345ebb0",
+   "metadata": {},
+   "source": [
+    "Run the code below to show a box plot of the data grouped by day of the week:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebe8fcb7-342b-459e-8b51-3112edc7b328",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = px.box(\n",
+    "    data,\n",
+    "    x='Day Name',\n",
+    "    y='Number of Users: Active',\n",
+    "    category_orders={'Day Name': ('Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat')},\n",
+    ")\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78503d11-a84c-4ead-be72-cb963efb5149",
+   "metadata": {},
+   "source": [
+    "## Details of the `get_data()` method\n",
+    "\n",
+    "Now that you have seen a basic example of using the `get_data()` method, read below for more details on how it works."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd5494a4-d368-43fc-8662-af92f9304a87",
+   "metadata": {},
+   "source": [
+    "### Wrap data warehouse calls in a runtime context\n",
+    "\n",
+    "XDMoD data is accessed over a network connection, which involves establishing connections and creating temporary resources. To ensure these connections and resources are cleaned up properly in spite of any runtime errors, you should call data warehouse methods within a **runtime context** by using Python's `with` statement to wrap the execution of XDMoD queries, store the result, and execute any long running calculations outside of the runtime context, as in the template below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "faf12b0f-96ef-490e-9a37-de11c5d98ad4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    # XDMoD queries would go here\n",
+    "    pass\n",
+    "# Data processing would go here\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0d75eac-6bad-45e7-9f34-b687625ffc0e",
+   "metadata": {},
+   "source": [
+    "### Default parameters\n",
+    "\n",
+    "The `get_data()` method has a number of parameters; their default values are shown below, and the parameters are explained in more detail further below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49269fae-eb5e-43e7-adb0-f06997d65f14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_data(\n",
+    "        duration='Previous month',\n",
+    "        realm='Jobs',\n",
+    "        metric='CPU Hours: Total',\n",
+    "        dimension='None',\n",
+    "        filters={},\n",
+    "        dataset_type='timeseries',\n",
+    "        aggregation_unit='Auto',\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17f8700f-2c7e-4fad-a1b3-a284ab0eb3cd",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Duration\n",
+    "\n",
+    "The **duration** provides the time constraints of the data to be fetched from the XDMoD data warehouse.\n",
+    "\n",
+    "As already seen, you can specify the duration as start and end times:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81f614c6-7d93-4d31-9f68-9c444a89e138",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_data(duration=('2023-01-01', '2023-04-30'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92660973-e0cc-4780-8b1c-02e8307c2de6",
+   "metadata": {},
+   "source": [
+    "You can instead specify the duration using a special string value; a list of the valid values can be obtained by calling the `get_durations()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c68c30a6-584d-4b8f-9c6b-63ea281d2def",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    durations = dw.get_durations()\n",
+    "display(durations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a31ed751-8105-49c4-9f06-5a61baeff145",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Realm\n",
+    "\n",
+    "A **realm** is a category of data in the XDMoD data warehouse. You can use the `describe_realms()` method to get a DataFrame containing the list of available realms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f9186a0-aaec-4c5b-bc31-986e31dc7024",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    realms = dw.describe_realms()\n",
+    "display_df_md_table(realms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37ec00eb-faf6-4682-9a74-05d41f86827b",
+   "metadata": {},
+   "source": [
+    "### Metric\n",
+    "\n",
+    "A **metric** is a statistic for which data exists in a given realm. You can use the `describe_metrics(realm)` method to get a DataFrame containing the list of valid metrics in the given realm. The realm must be passed in as a string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a2ee263-0d0c-4e6c-b954-66c24ef45fd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    metrics = dw.describe_metrics('Jobs')\n",
+    "display_df_md_table(metrics)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "511389a5-14f1-489b-8495-3340ab2c85c9",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Dimension\n",
+    "\n",
+    "A **dimension** is a grouping of data. You can use the `describe_dimensions(realm)` method to get a DataFrame containing the list of valid dimensions in the given realm. The realm must be passed in as a string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc364eb1-c3d9-4724-82ab-897191e3e3f4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    dimensions = dw.describe_dimensions('Jobs')\n",
+    "display_df_md_table(dimensions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed274746-b736-4181-9e2d-6de6febf39a9",
+   "metadata": {},
+   "source": [
+    "The code below shows how to get data grouped by the `Resource` dimension and plot them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "651f122b-76aa-4812-99ec-56a33646521c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metric_label = 'Number of Users: Active'\n",
+    "with dw:\n",
+    "    data = dw.get_data(\n",
+    "        duration=('2023-01-01', '2023-04-30'),\n",
+    "        realm='Jobs',\n",
+    "        metric=metric_label,\n",
+    "        dimension='Resource',\n",
+    "    )\n",
+    "plot = px.line(data, labels={'value': metric_label})\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bac0e9fb-4442-40b4-8478-1e450bd93d58",
+   "metadata": {},
+   "source": [
+    "### Pass in realms, metrics, and dimensions using labels or IDs\n",
+    "\n",
+    "For methods in the API that take realms, metrics, and/or dimensions as arguments, you can pass them in as their labels or their IDs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9ce1937-c232-4b39-ae40-bd5af1743716",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_data(\n",
+    "        duration='10 year',\n",
+    "        realm='Allocations',\n",
+    "        metric='NUs: Allocated', # 'allocated_nu' also works\n",
+    "        dimension='Resource Type',  # 'resource_type' also works\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee8f3916-665b-4582-ac63-dabaf4570c72",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Filters\n",
+    "\n",
+    "**Filters** allow you to include only data that have certain values for given dimensions. You can use the `get_filter_values(realm, dimension)` method to get a DataFrame containing the list of valid filter values for the given dimension in the given realm. The realm and dimension must be passed in as strings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60c52451-bc4e-442e-a132-0e3be7ffae74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    filter_values = dw.get_filter_values('Jobs', 'Resource') # 'resource' also works\n",
+    "display_df_md_table(filter_values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58d1c81a-7d1a-437d-b8ac-41ad21ae1bf0",
+   "metadata": {},
+   "source": [
+    "For methods in the API that take filters as arguments, you must specify the filters as a dictionary in which the keys are dimensions (labels or IDs) and the values are string filter values (labels or IDs) or sequences of string filter values. For example, to return only data for which the field of science is biophysics and the resource is either NCSA Delta GPU or TACC Stampede2:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8d9d268-5964-4154-aaca-aeeed9a6b858",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_data(\n",
+    "        filters={\n",
+    "            'Field of Science': 'Biophysics', # 'fieldofscience': '246' also works\n",
+    "            'Resource': ( # 'resource' also works\n",
+    "                'NCSA DELTA GPU', # '3032' also works\n",
+    "                'STAMPEDE2 TACC', # '2825' also works\n",
+    "            ),\n",
+    "        },\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d95c4244-37f6-4458-8b5e-d5604f72c2c5",
+   "metadata": {},
+   "source": [
+    "### Dataset Type\n",
+    "\n",
+    "The **dataset type** can either be 'timeseries' (the default), in which data is grouped by a time [aggregation unit](#Aggregation-unit), or 'aggregate', in which the data is aggregated across the entire [duration](#Duration). For 'aggregate', the results are returned as a Pandas Series rather than a DataFrame.\n",
+    "\n",
+    "The code below shows how to create a bar plot of data aggregated over four months, grouped by resource."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a842212b-c9d0-4c71-b014-2c57b3a56cfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metric_label = 'Number of Users: Active'\n",
+    "with dw:\n",
+    "    data = dw.get_data(\n",
+    "        duration=('2023-01-01', '2023-04-30'),\n",
+    "        realm='Jobs',\n",
+    "        metric=metric_label,\n",
+    "        dimension='Resource',\n",
+    "        dataset_type='aggregate',\n",
+    "    )\n",
+    "plot = px.bar(data, labels={'value': metric_label})\n",
+    "plot.update_layout(\n",
+    "    showlegend=False,\n",
+    "    xaxis_automargin=True,\n",
+    ")\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf632a3b-73eb-4c0e-a001-96f5c2d1c3d4",
+   "metadata": {},
+   "source": [
+    "### Aggregation unit\n",
+    "\n",
+    "The **aggregation unit** specifies how data is aggregated by time. You can get a list of valid aggregation units by calling the `get_aggregation_units()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ddc3b39-1968-49e3-b269-6ed93e6dba3d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    display(dw.get_aggregation_units())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13c08ea7-df9d-410d-841d-0bd6670fd2ef",
+   "metadata": {},
+   "source": [
+    "## Additional Examples\n",
+    "\n",
+    "For additional examples, please see the [xdmod-notebooks repository](https://github.com/ubccr/xdmod-notebooks)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9cb8874-138a-45f4-a06b-244c67f510f2",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "![XDMoD](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAF0AAAAgCAYAAABwzXTcAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfaCR0QJxALRnmrAAAWJUlEQVRo3u16aXRVVbbut3Z7mjQngYRAGkIgiCChEYFCgiBRChBBryJQBUJZWkQuitcWRUFQaURKS1FUsApBrxEQEJGy1FKgiCIEEjpD36QjhIScnJxzsvdea8334yQB6oJC1Rvv/bjOMTLGyV7dXN9e85vN2sAv8v9ftm7detVj3njjjase8+GqT/7XYswu9fDw4cPXrl69ekdRUZHQdR2MRbp5vd6C7OzsX48bN85u6vv5559D0zTlhx070stKS01d1wGA6gL1LDktHUREmqpCUVUoigKPx0O6YdQriurouub4Yn3WmLtGhX5KyTeXbY9+bMaueNWjwuvSEKzn6Ns7Tn656u6S194twMP3X9/cl4iUNl3/3JYLkkSEhgYJn8+Qf3y+W/ndI3uIfxWoASM+iD16IuiLitIpOkpDVbWFjhmxZBoEX4wmO2XGOc/818Aaxhj/4u+HMOTmjpedS7vUw8zMzB/Xrl276PDhw88Gg0EADIrCcO7cuUGnT5+eBODt9evXIyoqCoMHD8aKFSvGVFZWrhBCKEQAY0Cgvr75ZRFjYIyBKQpsxyEpyVZUtcFxnIBlWTVvvPPezqSEln+8647b9320+hOMuevOi/Q5fqr2ibCNGYbGwB0JzoEDh0IgIi9j7KIXtmtP2ZCqGudzTVMAAFIyhOsFP1PV0B3A/n8V9HCDnHWuDtPqghxqlQAXhMK9ATAGaCrkP74L1K397KM9R09ULGmf3vq/f2ou5VIPN2/eDMuyns/IyPgRADRNhaaq0A0Du3fvXlJZWdli5MiRGDx4MIhIO3To0Hu2ZSmapkNVVaiqBikFhJAQnENwASEEpBAQQjAuuCk4jxVCpAguutqW9buSsoq976348PF/BhwATp+xYkkCQgAOJxAYyk4GsXTlrpH/3HfV+oN/4AEOzgHOASkBbkuq8dtR/w4lCElk2UC4AagPEYUbCDV1AtV+jsoarpRW2bEFe/3Z7Tuv+XDR4u/mExFGjPvwykG/6aabMGbMGNG+fftZPp8PjDFSVBWqopKqKpg3b/4iImIAMHv27HVVZ8+aum6QpqnQdJU0TYWUBMEdcCEgBSfBBQkhIQQH5xyy0SSEEAxEAAj+usCCt5e9/0EwHFa/+mbLedCrGqLA/okJVQVrPjvR+cJHRKSu3lh+PcyLDZgD2r4fa1z/Dugkz1OxkMQSW6iyXaoevibDLaO8CniIM81UofoMev6lvU+s+XTfkxs+HIfjJ89eGehNMnbs2I87dOiwWdM0pmkaqZrKDMNEQ0N43Pz581NeeOGFX505c+YWQ9dJ01Sm6ToZusFAFAAQ4EJETrqUjAvONFUZzaTsER/tHXa6vGRZZXmZxRQlYgVSAkQIN4THfbLus/tyBg1o1qOq2vFerClBNVRUnOY3v//xXhUAivZXYe3nB7pWlDXEa4YCIroAMGJ19VK/3D7r6urx6pJtbN3Gfaxp3NKVhRc7P3Z+Qjpn4fWX+qw48sNEz4Ft49Xaw/ddN2xIqwAPccbAWECAxk3On0dEndu1bXllnA4A+fn56NevHwYPHjyqtLT0ZCgcjlEYg6IoAKAFg8GV9fX1uq7rRsQKFCiqyizLQkpq6l2nSspe59yJBiHC7ZqGs9XVRX9a9PIhAIUANj04OfeVH2uq8zp27tIVIuLjFEXBudrat0+eKlndNi21hoiUzL4fxEFhF/l/xgDHdvr+7qGNyP+hDN26JOCOe9e1dyR5Iu0RA2IM4ATU1NrRTaP3HKhCVucEAMCzc7/9TfaIT3sHwzLNMFX7xVeLDm/6+uC3Qwdf89XFr/liS7Mc7gKAHbtLwRjbT0Sp3bP/u3LfsaCpKIzZAY7R93/+FBFNYP9kpZc96f369cOmTZvg8/lqdV2fxwDSdB2qqsEwDNQFAtlgrK+u69A1DZqmQVEUeD2eRVu3bNkmSLgF5xCCQwhO3HHQvVuWu2n+3/72Xry55K0fuR2asH9PUUjTdZJSQEpJtu3g75u3zgGAwn2lpsORoKoKASApCdR4HI+WhpVVy+7q0693cmQzzLydS2o83NR8OoUE0pLjkpvWzuqcACJqMfyeNZVz5h9Yuae4/qHjJeFRxUcCo3cW1T89dPQ3X475/aeriEgtK6+7JOpN5/6GHik4dy4EAP4Wie63hB05PFq0jqPFgeyColNRV0UvQ4cORUZGBl5++eVFnPMShTHoukaapsEwDGYYBlN1HZqmweVyU52/rtLlcr3UKqmVQRLgjfzNOWecO+jRLavZslauXA4AWL58ReGZitJddX4/k5IgpWSMAf66wND9B4o9hfsqDSZlHGNgnEuWme62or0qAYBVz7E5/8SLTXP6/aGRAIMQxDq0ddm+aA1EBCIgGLLTAMCV8hIK9lXrN9768Q8bN1Umal6dSBJM4zyYmqnSJxvK77rv4b8tT24T04g5XRanuDgPGGPo2yP6MBPnacgftNKXrjxgXhXoEVCWgzFm3XLLLcP8fj90XWdaI9C6psHQNBiGSefO1bDrrusy5dlnn60GAEkSwolELpwLcM5hWdYl1+jYsePq0xXlICkhhYCUgoQQUTt2FcaVlAU1ABFqcAjXdHCfTU/2nGg82viu4Gx/ACjcW9n2+8KaWMYAIkJ2n8R8lysCIkmgdYK7HQA0lD6NoqKS9/J/qM7QonTilmQ9sqLsJfP79p31aNbELh29jIiYUFW8t/Twb7ZuP/YQAAhBP+tsU1M9lXQBlZwLcuworFGuGvR7770Xq1atwtixY/cTsFhKQjOl6Do0TYeiMMYYW5ebm7vm9ddfB8BAUsDhHFzw5rCRpLzkGi7T3BWsD0BIASEFpJBMSqmfq611nzhVp3EuvBekcsEGh76VkqCaCm0vqNV27j7Va8t3Jx+qr3HAGCOXqSAxIWa2x62xJl6vOBPo0hjhxDz5QsFvmUsjImIJCTp2fTWuzYQxXbc/91jf5cnJnt+BGrkkSqfxD26b1OiN2c9hldI6JnChw7VsidNnLHbVoAOA2+1ucl+xLpcJXdMagddhGDpMlwuWZQ0AgKlTp0IBICWB8wjgXET+JF36tFi2Q5JkUxwfAV8IJoRgDZZUScI8H0Ww4C03JRRKS0TcKSe8u3Jf9savTg5HxMmzFtGakzMwvkgK3hxphsO8DQB88EnRuKpSC6oaaeiQ6q3+1ZDl1cWHarA5vwwT7m53WAezI/mJAjss0jd88WMCmPKzR33Ar5JtNFtEhNb4JSzkZ0GfN28ebrvtNsycOXOoEPy3brcbmqZHQNd1aJoBQ9epQ2Zm/NSpU/8CAExlEXrhDjh3IsA7zkVh3EVxNOfdDMNsjOkFhBAkhXCiozzhkrKQGrYbLUQSWiW4aiaO6fhdYzRD0BSUlFs53xfUJSumQlISVEM7PLh/p5rWrTycJAEM8AecWADY9OWprlAvsBtVKb5/Qld06hiPm/olo1dWYik0ZjeqymwhY9Z8dsyjKPhZ0AsKTxtQWXOEpWkMMVEaXTXoTz31FL7Lz0/Kz8/Py8rqBlXTSNd16IYB0zSh6xo0XWdej5fS2rYd+8i0ad05F5BCwnGcRj6PJEl0GRM9cuTIXb64eHCHQwoOKQQjokCv7p2r2qe3aGE51OzlOrSLq7y+W9udXTp7Le5IpmoMBXtqc0IN0qsoDLJB4LrOnv0A4IsxTjftOBSOvLhdRVUuGFqz0wwEeX1peaBZl5gYj2CKAjRi3GAJZfO2MrUxVP5JOXayNg4XJFE+r4aeWb6rA33JkiUAgLnz5s0eMOCmaFVToWs6M0wDAHMC9QGYpkmGbkDVVJbQMsGIi49flpCQaEspKUIvEeAF55Dy/Ppz584FADz+2GPXub1RvV0uF0UyWCLLthEbE73u+uv7WNHRahfLks1ZqBTOKQB46L7OmxDmYIxRVbVjSEmMGpHMvbfLZwDgcaunGSKcXlVtgYj0Fi08Ao16MAbERutG546+Zr1OlNQoEYuMYKdrCq5pH0eXs9IL5YfCc8kX9KL4aKPmzhHpzhWD/s0332Dy5Mn4+OOPe7ZqlXR/VHQUVFWFbkRoJTEx4e5TJ08WGYbBNF2DoRswDIPS2rbtqWnaDClEmDtOxJlyB9xx4HK5mj3p9OnTUVpyIvrIsRMfprVt52kIh5mQEpw7TFNVTJl8/wwA8EWbPTmn5ri4y7WJRwGgY4eEWZ4WBogIihJJhgSXrFsPH0YM6fQ+AERHucubQKgPE6qrazvkZLcpg3W+2GhbImX3vtrz/zuyJTlSa/IF0aYafOgPWQ1CyMuCXVVdDwAoL+MjFDPCL9wW0L3a9tEjsgJXDPqgQYNARPpHH330dZcuXaCqKgzDIEM34Ha5tiS2StxIRI9WVJSLqKhoMkwDuq6z+Lh4Sk5JfcrhPNNxGvmccxAIGzduzJgwcVLmlClTe/4hN/fhRx59qqZV69ZdhRDUGOUQdxwkJiTc11Q9PF0VuCZi6QTDo8LQtUIAGNQ/rahzh6j6SKgUqd2AEwb3T9retIdg2C6NZIMMVoPE5vyTmVPv7/5XGKw5wXIcnvHSjIHN+/70i5PtSEojUqEkIl0pGzq4YzUksQvSU5i60vwWWsYL1zvvF/3mH9vPDFQi2hALc/bGvF55jDF5RaB/8803ICJMGD9hbq8bbvC53C4yDAONNIKUlJTHhtxyK3/33Xe/rqw8/XU4HGKmaZJhmmCMsfT0dPS/8Ualvr6+OYJxHAd79uz9qCHc8OM5f21BfTD0alR0jMY5J845E1xQuCHM4uN8K2779bA/r1qztrE0i7SmYx7tUdA2xXOsSU9dN76IMEEEWJdXhaYbTze1m6ZZzlhjsy1QF5Q9WsTHbh89KrVahAQDgD3FAXXB6/lvNo3Zt7/uSR4hcJJ+m90+pE0+Y8xmKjvPHF4Ni/98eGD3gSs/7ZK9YlOHGzbseHzmjpX+kCQwBuG32TPPdN/ap2fG8iuqMq5fvx6DBg3CokWL0tokt3k4MTGRVFVlhm5A0zTWOinpT7feeuuOb7+NVAFfe+1Pd5SVlnLDMJmh6zBdJjRNw/Dhw5GWmoKGcAhNJ15IoTrcUR2HkxSNDpY7TAgOx7EdX0zsq89Mf3LCW++8RXf/xx0AgIrKYFJT3BflVdGpY3JNk65pKdpX4OcdRVK8YTt2aP9Xm0sAADW14dJm/8cYfthZ0RUAJo69rn+LhEgKqmgqPfH07twOvZdTu15/ob99XdlLURhxW7A+A1rai+fnTIq4k/MHXXNr9O22s60L99WP2F8c+vXx0tB1QYtIUcC4I9iQnNYnX3i6/4C/bz12ZaXdkSNHgohcFRUVO9tlZGiqojLDMGAYBjwez8mExFZPAsDAgQPwxRdfgDEWSkxMmOg4NkyXiwzDhGEYMEwT9/3+92QYBhzbjkQyTiSEdGybCSFARELX9KMu03wtMaFln7kvzn7kyenPYEB2/2Z9KiqtBDgSwpZoyjs2fnUcADBtctZu6RBxS4KHBQSUvU9N6+XPuSm1iZ+riBO4LYCwQH1YtgWAYTnpxfeMysht4VPBQ4KpUQaOnLBw/JQNxaUSD3J2baa3+sXpfbs16eE4UhchAR7i4JZkIAACgCBIS4LXOyyphY57787Iy/tgQB8AuDk748pvjtasWeNOT2831G26HCgMqqqCgSG+RfzpPr1vaGjqN2TIEGzZsgUtW7ZcfejgwadM0+jCmEKaFrnIaNUqiT0zY8bSF1544V3D0JmmaoiJiaFbbr01VFVVdW7wzYMqu3fvzgFg7vwFAID5c1/E/LnndUlPdR3yxTANjCG1TVTtiUJgeE47AMCverXbPuaB9TvLKuoThCNxc3bK2lYJ8c36tUnUSwf1jz0mieDYUvG6lWIAeO2d3Xj4gR5LthecXjNrwbbNW7ZXJTcyCgydsXvGZ+S/+fKQX+cMvKAAeEPigWuvcU4IQdxfZynhMGct493CEVLGRmnBPj0TC6fl3jidMVb50OTSqyvW5+Xl/WT755s2XfL5rl27rvnu++/v21mwa+Lu3UUT9+7dO3Hf/gMTS0rLOv3UfAteXnjZtjvvXfM/nj3x/N8vrIX+j/ZHnvkSAPDB6oOXnPP+aZ9Fakp5xT+Lxd++PQUAePjpv14xflvyj/3fu8EeNWrU//Nb85kzZ0au4Fat+sl+Xbt2bf49YsSIZiv8V+Xtt99u/h2pJf28LFy48N/7GuBy8sADDzzxzjvvLJgzZ07qkSNH7ly+fPlr48ePn2qaJtd1PSErK+u1goKCSZZlmYqiuHNycvI2bNiQFh0d3b6hoUEfNmzYke3bt++srKwcnZeX9/qkSZMe4ZG7UvWee+5559SpU122bdt2raIovFOnTmXPPfdc83caCxYsiDp69Og0t9uthMNh5c4773xr5cqVrVNSUm6cO3fu4lGjRv1BCPHZhg0byprG3H777RNdLleKYRhIT0//pGfPnke3bt36QDgcFoyx6Lfeemv+zJkzc2fNmvU2gOjx48dPNk1z4bJly8TMmTNHtWzZMjh16tQvX3nlleQDBw7cs2zZskW33XbbEFVVi/v162fu3r17rKIook2bNscWLlz44ZXiqFwN6KFQaP7KlSvfNAzjLwBme71eXdO05+Lj4++JjY39MBwO+5cuXfqq1+t9XNf1zZWVlQcNw/h9VFRUJyK6oby8fI6UMk1RlBd79+4dzzmf//77789KTk42Dx06pDc0NPxnMBh8NhwOPyqlHHrh2sXFxR2klJ2ys7MX2bbdpqioKMc0zetramr+OGPGjGWGYTwTCoUu+u7BcZwZ11577RdpaWlrAoHAX++44w5mGMbzcXFxdw0fPnzd2rVrVdu2H549e/ahxYsXz2GMzTtw4IBBREYoFHqluLh4TeO+OwshXpkyZcp2n893m6Io7Q8ePHiz1+utzczM/COAOVeD41WBXl9fv7WwsDDT7/cfk1IqHo+HhBDe0tJSp6Ki4v6kpKQWjeVTnXNur1u3Tkop3Zqm1fp8vmFut3uhYRguIYRr0qRJYUVR9AkTJuSePXv27lAo1Nrr9R5u27ZtWefOna3jx49nX7i21+ttsG27x6effporpewTGxvr55zHqqr6nM/nq4qNjU11HCd48b0m08rLy8efPXt2msfjKfj+++81IYSrrKxM5OXljR81apRMTk72JyQkLK+qqhI1NTXOlClTlFmzZu0tKys7WVdXt+/xxx//Kjo62uX3+3cJId51uVz/aVmWjImJ4UQ0rKys7ImrZYyrAl0IMWzs2LFDKysrc4kotaqqihNRGyIaLYRYIIRoyqfTGGPfu1wuCCHGjBs3bqZpmqklJSXr3W53vhAiMTc3N6woSpwQIo9zfn1mZuZ2v9//XFlZ2YBDhw71TUpKuuHCtZOSkg4CyOacLyOiQd26ddsEYHEoFHr10UcfnQ4g3jCMgos2pyhZwWBwVjAYnJ6Wljb68OHDQcuy2gghRgcCgUWMMbJtO+fBBx+ck5OT85hlWYkjR44MVVRU9FUUZYiiKAODweCdPp9vkxBi4JIlS5bquh5n2/Y/EhMTl9u2PTYcDr9mGEbWL98G/iK/yC/yi/zvlP8DXh8lEQYro5IAAAAASUVORK5CYII=) XDMoD Data Analytics Framework"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/XDMoD-Data-First-Example-JupyterHub.ipynb
+++ b/XDMoD-Data-First-Example-JupyterHub.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# XDMoD Data Analytics Framework — First Example for JupyterHub\n",
     "\n",
-    "Notebook v1.1.0 (2025-07-14)\n",
+    "Notebook v2.0 (2025-07-14)\n",
     "\n",
     "Compatible with XDMoD Data Analytics Framework v≥1.0.0 and <2.0.0\n",
     "\n",

--- a/XDMoD-Data-Machine-Learning-JupyterHub.ipynb
+++ b/XDMoD-Data-Machine-Learning-JupyterHub.ipynb
@@ -1,0 +1,657 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# XDMoD Data Analytics Framework — Machine Learning Example for JupyterHub\n",
+    "\n",
+    "Notebook v1.1.0 (2025-07-14)\n",
+    "\n",
+    "Compatible with XDMoD Data Analytics Framework v≥1.0.0 and <2.0.0\n",
+    "\n",
+    "© 2023–2024 University at Buffalo Center for Computational Research\n",
+    "\n",
+    "See the [xdmod-notebooks](https://github.com/ubccr/xdmod-notebooks) repository for licensing information."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Introduction\n",
+    "The XDMoD Data Analytics Framework provides API access to the data in XDMoD via the [`xdmod_data` Python module](https://pypi.org/project/xdmod-data). This notebook provides an example showing how to use the `get_raw_data()` method to obtain and process raw job performance data, which is contained in the `SUPREMM` realm in XDMoD, and use the data to train a machine learning model to classify applications based on their performance characteristics."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Configure notebook formatting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exceptions\n",
+    "Run the code below to simplify how Python exceptions are displayed in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "def exception_handler(exception_type, exception, traceback):\n",
+    "    print(\"%s: %s\" % (exception_type.__name__, exception), file=sys.stderr)\n",
+    "get_ipython()._showtraceback = exception_handler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tables\n",
+    "Run the code below to set up for displaying Pandas DataFrames as Markdown tables in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, Markdown\n",
+    "def display_df_md_table(df):\n",
+    "    return display(Markdown(df.replace('\\n', '<br/>', regex=True).to_markdown()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plots\n",
+    "Run the code below to set up the external Plotly library to make plots using a custom XDMoD theme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "import plotly.graph_objects as go\n",
+    "import plotly.io as pio\n",
+    "import xdmod_data.themes\n",
+    "pio.templates.default = \"timeseries\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize the XDMoD Data Warehouse\n",
+    "Run the code below to prepare for getting data from the XDMoD data warehouse at the given URL. If no host is specified, the XDMOD_HOST environment variable is used to determine the host."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from xdmod_data.warehouse import DataWarehouse\n",
+    "dw = DataWarehouse()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Get the raw data\n",
+    "\n",
+    "Use the `get_raw_data()` method to request raw data from XDMoD and load them into a Pandas DataFrame. For example, get two months of job performance data for the ACCESS-allocated Bridges-2 resource. Each of the parameters of the `get_raw_data()` method will be explained later in this notebook. Use `with` to create a runtime context; this is also explained later in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "JSONDecodeError: Extra data: line 1 column 2 (char 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_raw_data(\n",
+    "        duration=('2023-01-01', '2023-02-28'),\n",
+    "        realm='SUPREMM',\n",
+    "        fields=(\n",
+    "            'Application',\n",
+    "            'CPU User',\n",
+    "            'CPU User cov',\n",
+    "            'Wall Time',\n",
+    "            'Total memory used',\n",
+    "            'Net Ib0 Rx',\n",
+    "            'Net Ib0 Tx',\n",
+    "            'Memory Used Cov',\n",
+    "            'Net Ib0 Rx Cov',\n",
+    "            'Net Ib0 Tx Cov',\n",
+    "        ),\n",
+    "        filters={\n",
+    "            'Resource': [\n",
+    "                'Bridges 2 RM',\n",
+    "            ],\n",
+    "        },\n",
+    "        show_progress=True,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "display(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare data for training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get a list of the most used applications in the data set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "application_counts = data['Application'].value_counts()\n",
+    "display(application_counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looking at the list of applications, it should be noted:\n",
+    "\n",
+    "* \"NA\" means the application name was not collected.\n",
+    "* \"uncategorized\" means the application name was collected but is not in the list of applications known to XDMoD.\n",
+    "* \"PROPRIETARY\" means the application is one whose software license does not allow performance data about the application to be reported in conjunction with the application's name.\n",
+    "* \"python\" and \"r\" could consist of multiple different codes running in the Python and R programming languages, rather than specific application packages.\n",
+    "\n",
+    "With that in mind, only include jobs running the top eight individual application packages from the list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "applications = ('orca', 'lammps', 'q-espresso', 'gromacs', 'specfem2d', 'namd', 'gdal', 'qmcchem')\n",
+    "data = data[data['Application'].isin(applications)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One thing of which to be careful is that there may be some records that have `<NA>` values, indicating a particular record was not collected.\n",
+    "\n",
+    "Filter out the jobs for which any value is `<NA>`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "data = data.dropna()\n",
+    "display(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert the values from all the columns except \"Application\" from strings to floating point values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conversions = {}\n",
+    "for column in data.columns.drop('Application').values:\n",
+    "    conversions[column] = float\n",
+    "data = data.astype(conversions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use [scikit-learn](https://scikit-learn.org/) to split the jobs into a training set and test set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.model_selection import train_test_split\n",
+    "X = data[[\n",
+    "    'CPU User',\n",
+    "    'CPU User cov',\n",
+    "    'Wall Time',\n",
+    "    'Total memory used',\n",
+    "    'Net Ib0 Rx',\n",
+    "    'Net Ib0 Tx',\n",
+    "    'Memory Used Cov',\n",
+    "    'Net Ib0 Rx Cov',\n",
+    "    'Net Ib0 Tx Cov',\n",
+    "]]\n",
+    "y = data['Application']\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.10)\n",
+    "display(Markdown(\"Size of the test subset is **\" + str(len(X_test)) + \"**.\"))\n",
+    "display(Markdown(\"Size of the training subset is **\" + str(len(X_train)) + \"**.\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate a Random Forest Classification model\n",
+    "\n",
+    "Using the tools from `scikit-learn`, build a Random Forest Classification model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "\n",
+    "classifier = RandomForestClassifier(oob_score=True)\n",
+    "classifier.fit(X_train, y_train)\n",
+    "print('oob score:', classifier.oob_score_)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute feature importances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "importances = pd.Series(\n",
+    "    classifier.feature_importances_,\n",
+    "    index=pd.Index(\n",
+    "        X_train.columns,\n",
+    "        name='Feature Name',\n",
+    "    ),\n",
+    "    name='Importance',\n",
+    ").sort_values(ascending=False)\n",
+    "display_df_md_table(importances)\n",
+    "plot = px.bar(importances, y='Importance')\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create confusion matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay\n",
+    "matrix = confusion_matrix(y_test, classifier.predict(X_test), labels=applications)\n",
+    "cmd = ConfusionMatrixDisplay(matrix, display_labels=applications)\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.rcParams.update(plt.rcParamsDefault)\n",
+    "plt.rcParams.update({\n",
+    "    'font.size': 16,\n",
+    "    'figure.figsize': (7, 7),\n",
+    "    'axes.labelpad': 20,\n",
+    "})\n",
+    "cmd.plot(\n",
+    "    colorbar=False,\n",
+    "    xticks_rotation='vertical',\n",
+    "    values_format='.0f',\n",
+    "    cmap='Blues',\n",
+    ")\n",
+    "# Export the figure as PDF\n",
+    "#plt.savefig('confusion_matrix.pdf', bbox_inches='tight')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Details of the `get_raw_data()` method\n",
+    "Now that you have seen an example of using the `get_raw_data()` method, read below for more details on how it works."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Wrap data warehouse calls in a runtime context\n",
+    "XDMoD data is accessed over a network connection, which involves establishing connections and creating temporary resources. To ensure these connections and resources are cleaned up properly in spite of any runtime errors, you should call data warehouse methods within a **runtime context** by using Python's `with` statement to wrap the execution of XDMoD queries, store the result, and execute any long running calculations outside of the runtime context, as in the template below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    # XDMoD queries would go here\n",
+    "    pass\n",
+    "# Data processing would go here\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parameters\n",
+    "The `get_raw_data()` method has a number of parameters explained in detail below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Duration\n",
+    "The **duration** provides the time constraints of the data to be fetched from the XDMoD data warehouse.\n",
+    "\n",
+    "As already seen, you can specify the duration as start and end dates. These are both inclusive, so if you only want one day of data, use the same date for start and end:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_raw_data(\n",
+    "        duration=('2023-05-01', '2023-05-01'),\n",
+    "        realm='SUPREMM'\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can instead specify the duration using a special string value; a list of the valid values can be obtained by calling the `get_durations()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    durations = dw.get_durations()\n",
+    "display(durations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Realm\n",
+    "A **realm** is a category of data in the XDMoD data warehouse. You can use the `describe_raw_realms()` method to get a DataFrame containing the list of realms for which raw data is available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    raw_realms = dw.describe_raw_realms()\n",
+    "display_df_md_table(raw_realms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Fields\n",
+    "A **field** is a measurement for which raw data exists in a given realm. You can use the `describe_raw_fields(realm)` method to get a DataFrame containing the list of valid fields in the given realm. The realm must be passed in as a string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    raw_fields = dw.describe_raw_fields('SUPREMM')\n",
+    "display_df_md_table(raw_fields)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filters\n",
+    "**Filters** allow you to include only data that have certain values for given **dimensions**, which are groupings of data. You can use the `describe_dimensions(realm)` method to get a DataFrame containing the list of valid dimensions in the given realm. The realm must be passed in as a string and can be either the ID or the label of the realm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    dimensions = dw.describe_dimensions('SUPREMM')\n",
+    "display_df_md_table(dimensions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can use the `get_filter_values(realm, dimension)` method to get a DataFrame containing the list of valid filter values for the given dimension in the given realm. The realm and dimension must be passed in as strings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    filter_values = dw.get_filter_values('SUPREMM', 'Resource') # 'resource' also works\n",
+    "display_df_md_table(filter_values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For methods in the API that take filters as arguments, you must specify the filters as a dictionary in which the keys are dimensions (labels or IDs) and the values are string filter values (labels or IDs) or sequences of string filter values. For example, to return only data for which the field of science is Materials Engineering and the resource is either Bridges-2 RM or TACC Stampede2:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_raw_data(\n",
+    "        duration=('2021-05-01', '2021-05-01'),\n",
+    "        realm='SUPREMM',\n",
+    "        filters={\n",
+    "            'Field of Science': 'Materials Engineering', # 'fieldofscience': '177' also works\n",
+    "            'Resource': ( # 'resource' also works\n",
+    "                'Bridges 2 RM', # '2900' also works\n",
+    "                'STAMPEDE2 TACC', # '2825' also works\n",
+    "            ),\n",
+    "        },\n",
+    "        show_progress=True\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Show progress\n",
+    "Set the `show_progress` parameter to `True` to periodically print how many rows have been gotten so far. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional Examples\n",
+    "For additional examples, please see the [xdmod-notebooks repository](https://github.com/ubccr/xdmod-notebooks)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "![XDMoD](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAF0AAAAgCAYAAABwzXTcAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfaCR0QJxALRnmrAAAWJUlEQVRo3u16aXRVVbbut3Z7mjQngYRAGkIgiCChEYFCgiBRChBBryJQBUJZWkQuitcWRUFQaURKS1FUsApBrxEQEJGy1FKgiCIEEjpD36QjhIScnJxzsvdea8334yQB6oJC1Rvv/bjOMTLGyV7dXN9e85vN2sAv8v9ftm7detVj3njjjase8+GqT/7XYswu9fDw4cPXrl69ekdRUZHQdR2MRbp5vd6C7OzsX48bN85u6vv5559D0zTlhx070stKS01d1wGA6gL1LDktHUREmqpCUVUoigKPx0O6YdQriurouub4Yn3WmLtGhX5KyTeXbY9+bMaueNWjwuvSEKzn6Ns7Tn656u6S194twMP3X9/cl4iUNl3/3JYLkkSEhgYJn8+Qf3y+W/ndI3uIfxWoASM+iD16IuiLitIpOkpDVbWFjhmxZBoEX4wmO2XGOc/818Aaxhj/4u+HMOTmjpedS7vUw8zMzB/Xrl276PDhw88Gg0EADIrCcO7cuUGnT5+eBODt9evXIyoqCoMHD8aKFSvGVFZWrhBCKEQAY0Cgvr75ZRFjYIyBKQpsxyEpyVZUtcFxnIBlWTVvvPPezqSEln+8647b9320+hOMuevOi/Q5fqr2ibCNGYbGwB0JzoEDh0IgIi9j7KIXtmtP2ZCqGudzTVMAAFIyhOsFP1PV0B3A/n8V9HCDnHWuDtPqghxqlQAXhMK9ATAGaCrkP74L1K397KM9R09ULGmf3vq/f2ou5VIPN2/eDMuyns/IyPgRADRNhaaq0A0Du3fvXlJZWdli5MiRGDx4MIhIO3To0Hu2ZSmapkNVVaiqBikFhJAQnENwASEEpBAQQjAuuCk4jxVCpAguutqW9buSsoq976348PF/BhwATp+xYkkCQgAOJxAYyk4GsXTlrpH/3HfV+oN/4AEOzgHOASkBbkuq8dtR/w4lCElk2UC4AagPEYUbCDV1AtV+jsoarpRW2bEFe/3Z7Tuv+XDR4u/mExFGjPvwykG/6aabMGbMGNG+fftZPp8PjDFSVBWqopKqKpg3b/4iImIAMHv27HVVZ8+aum6QpqnQdJU0TYWUBMEdcCEgBSfBBQkhIQQH5xyy0SSEEAxEAAj+usCCt5e9/0EwHFa/+mbLedCrGqLA/okJVQVrPjvR+cJHRKSu3lh+PcyLDZgD2r4fa1z/Dugkz1OxkMQSW6iyXaoevibDLaO8CniIM81UofoMev6lvU+s+XTfkxs+HIfjJ89eGehNMnbs2I87dOiwWdM0pmkaqZrKDMNEQ0N43Pz581NeeOGFX505c+YWQ9dJ01Sm6ToZusFAFAAQ4EJETrqUjAvONFUZzaTsER/tHXa6vGRZZXmZxRQlYgVSAkQIN4THfbLus/tyBg1o1qOq2vFerClBNVRUnOY3v//xXhUAivZXYe3nB7pWlDXEa4YCIroAMGJ19VK/3D7r6urx6pJtbN3Gfaxp3NKVhRc7P3Z+Qjpn4fWX+qw48sNEz4Ft49Xaw/ddN2xIqwAPccbAWECAxk3On0dEndu1bXllnA4A+fn56NevHwYPHjyqtLT0ZCgcjlEYg6IoAKAFg8GV9fX1uq7rRsQKFCiqyizLQkpq6l2nSspe59yJBiHC7ZqGs9XVRX9a9PIhAIUANj04OfeVH2uq8zp27tIVIuLjFEXBudrat0+eKlndNi21hoiUzL4fxEFhF/l/xgDHdvr+7qGNyP+hDN26JOCOe9e1dyR5Iu0RA2IM4ATU1NrRTaP3HKhCVucEAMCzc7/9TfaIT3sHwzLNMFX7xVeLDm/6+uC3Qwdf89XFr/liS7Mc7gKAHbtLwRjbT0Sp3bP/u3LfsaCpKIzZAY7R93/+FBFNYP9kpZc96f369cOmTZvg8/lqdV2fxwDSdB2qqsEwDNQFAtlgrK+u69A1DZqmQVEUeD2eRVu3bNkmSLgF5xCCQwhO3HHQvVuWu2n+3/72Xry55K0fuR2asH9PUUjTdZJSQEpJtu3g75u3zgGAwn2lpsORoKoKASApCdR4HI+WhpVVy+7q0693cmQzzLydS2o83NR8OoUE0pLjkpvWzuqcACJqMfyeNZVz5h9Yuae4/qHjJeFRxUcCo3cW1T89dPQ3X475/aeriEgtK6+7JOpN5/6GHik4dy4EAP4Wie63hB05PFq0jqPFgeyColNRV0UvQ4cORUZGBl5++eVFnPMShTHoukaapsEwDGYYBlN1HZqmweVyU52/rtLlcr3UKqmVQRLgjfzNOWecO+jRLavZslauXA4AWL58ReGZitJddX4/k5IgpWSMAf66wND9B4o9hfsqDSZlHGNgnEuWme62or0qAYBVz7E5/8SLTXP6/aGRAIMQxDq0ddm+aA1EBCIgGLLTAMCV8hIK9lXrN9768Q8bN1Umal6dSBJM4zyYmqnSJxvK77rv4b8tT24T04g5XRanuDgPGGPo2yP6MBPnacgftNKXrjxgXhXoEVCWgzFm3XLLLcP8fj90XWdaI9C6psHQNBiGSefO1bDrrusy5dlnn60GAEkSwolELpwLcM5hWdYl1+jYsePq0xXlICkhhYCUgoQQUTt2FcaVlAU1ABFqcAjXdHCfTU/2nGg82viu4Gx/ACjcW9n2+8KaWMYAIkJ2n8R8lysCIkmgdYK7HQA0lD6NoqKS9/J/qM7QonTilmQ9sqLsJfP79p31aNbELh29jIiYUFW8t/Twb7ZuP/YQAAhBP+tsU1M9lXQBlZwLcuworFGuGvR7770Xq1atwtixY/cTsFhKQjOl6Do0TYeiMMYYW5ebm7vm9ddfB8BAUsDhHFzw5rCRpLzkGi7T3BWsD0BIASEFpJBMSqmfq611nzhVp3EuvBekcsEGh76VkqCaCm0vqNV27j7Va8t3Jx+qr3HAGCOXqSAxIWa2x62xJl6vOBPo0hjhxDz5QsFvmUsjImIJCTp2fTWuzYQxXbc/91jf5cnJnt+BGrkkSqfxD26b1OiN2c9hldI6JnChw7VsidNnLHbVoAOA2+1ucl+xLpcJXdMagddhGDpMlwuWZQ0AgKlTp0IBICWB8wjgXET+JF36tFi2Q5JkUxwfAV8IJoRgDZZUScI8H0Ww4C03JRRKS0TcKSe8u3Jf9savTg5HxMmzFtGakzMwvkgK3hxphsO8DQB88EnRuKpSC6oaaeiQ6q3+1ZDl1cWHarA5vwwT7m53WAezI/mJAjss0jd88WMCmPKzR33Ar5JtNFtEhNb4JSzkZ0GfN28ebrvtNsycOXOoEPy3brcbmqZHQNd1aJoBQ9epQ2Zm/NSpU/8CAExlEXrhDjh3IsA7zkVh3EVxNOfdDMNsjOkFhBAkhXCiozzhkrKQGrYbLUQSWiW4aiaO6fhdYzRD0BSUlFs53xfUJSumQlISVEM7PLh/p5rWrTycJAEM8AecWADY9OWprlAvsBtVKb5/Qld06hiPm/olo1dWYik0ZjeqymwhY9Z8dsyjKPhZ0AsKTxtQWXOEpWkMMVEaXTXoTz31FL7Lz0/Kz8/Py8rqBlXTSNd16IYB0zSh6xo0XWdej5fS2rYd+8i0ad05F5BCwnGcRj6PJEl0GRM9cuTIXb64eHCHQwoOKQQjokCv7p2r2qe3aGE51OzlOrSLq7y+W9udXTp7Le5IpmoMBXtqc0IN0qsoDLJB4LrOnv0A4IsxTjftOBSOvLhdRVUuGFqz0wwEeX1peaBZl5gYj2CKAjRi3GAJZfO2MrUxVP5JOXayNg4XJFE+r4aeWb6rA33JkiUAgLnz5s0eMOCmaFVToWs6M0wDAHMC9QGYpkmGbkDVVJbQMsGIi49flpCQaEspKUIvEeAF55Dy/Ppz584FADz+2GPXub1RvV0uF0UyWCLLthEbE73u+uv7WNHRahfLks1ZqBTOKQB46L7OmxDmYIxRVbVjSEmMGpHMvbfLZwDgcaunGSKcXlVtgYj0Fi08Ao16MAbERutG546+Zr1OlNQoEYuMYKdrCq5pH0eXs9IL5YfCc8kX9KL4aKPmzhHpzhWD/s0332Dy5Mn4+OOPe7ZqlXR/VHQUVFWFbkRoJTEx4e5TJ08WGYbBNF2DoRswDIPS2rbtqWnaDClEmDtOxJlyB9xx4HK5mj3p9OnTUVpyIvrIsRMfprVt52kIh5mQEpw7TFNVTJl8/wwA8EWbPTmn5ri4y7WJRwGgY4eEWZ4WBogIihJJhgSXrFsPH0YM6fQ+AERHucubQKgPE6qrazvkZLcpg3W+2GhbImX3vtrz/zuyJTlSa/IF0aYafOgPWQ1CyMuCXVVdDwAoL+MjFDPCL9wW0L3a9tEjsgJXDPqgQYNARPpHH330dZcuXaCqKgzDIEM34Ha5tiS2StxIRI9WVJSLqKhoMkwDuq6z+Lh4Sk5JfcrhPNNxGvmccxAIGzduzJgwcVLmlClTe/4hN/fhRx59qqZV69ZdhRDUGOUQdxwkJiTc11Q9PF0VuCZi6QTDo8LQtUIAGNQ/rahzh6j6SKgUqd2AEwb3T9retIdg2C6NZIMMVoPE5vyTmVPv7/5XGKw5wXIcnvHSjIHN+/70i5PtSEojUqEkIl0pGzq4YzUksQvSU5i60vwWWsYL1zvvF/3mH9vPDFQi2hALc/bGvF55jDF5RaB/8803ICJMGD9hbq8bbvC53C4yDAONNIKUlJTHhtxyK3/33Xe/rqw8/XU4HGKmaZJhmmCMsfT0dPS/8Ualvr6+OYJxHAd79uz9qCHc8OM5f21BfTD0alR0jMY5J845E1xQuCHM4uN8K2779bA/r1qztrE0i7SmYx7tUdA2xXOsSU9dN76IMEEEWJdXhaYbTze1m6ZZzlhjsy1QF5Q9WsTHbh89KrVahAQDgD3FAXXB6/lvNo3Zt7/uSR4hcJJ+m90+pE0+Y8xmKjvPHF4Ni/98eGD3gSs/7ZK9YlOHGzbseHzmjpX+kCQwBuG32TPPdN/ap2fG8iuqMq5fvx6DBg3CokWL0tokt3k4MTGRVFVlhm5A0zTWOinpT7feeuuOb7+NVAFfe+1Pd5SVlnLDMJmh6zBdJjRNw/Dhw5GWmoKGcAhNJ15IoTrcUR2HkxSNDpY7TAgOx7EdX0zsq89Mf3LCW++8RXf/xx0AgIrKYFJT3BflVdGpY3JNk65pKdpX4OcdRVK8YTt2aP9Xm0sAADW14dJm/8cYfthZ0RUAJo69rn+LhEgKqmgqPfH07twOvZdTu15/ob99XdlLURhxW7A+A1rai+fnTIq4k/MHXXNr9O22s60L99WP2F8c+vXx0tB1QYtIUcC4I9iQnNYnX3i6/4C/bz12ZaXdkSNHgohcFRUVO9tlZGiqojLDMGAYBjwez8mExFZPAsDAgQPwxRdfgDEWSkxMmOg4NkyXiwzDhGEYMEwT9/3+92QYBhzbjkQyTiSEdGybCSFARELX9KMu03wtMaFln7kvzn7kyenPYEB2/2Z9KiqtBDgSwpZoyjs2fnUcADBtctZu6RBxS4KHBQSUvU9N6+XPuSm1iZ+riBO4LYCwQH1YtgWAYTnpxfeMysht4VPBQ4KpUQaOnLBw/JQNxaUSD3J2baa3+sXpfbs16eE4UhchAR7i4JZkIAACgCBIS4LXOyyphY57787Iy/tgQB8AuDk748pvjtasWeNOT2831G26HCgMqqqCgSG+RfzpPr1vaGjqN2TIEGzZsgUtW7ZcfejgwadM0+jCmEKaFrnIaNUqiT0zY8bSF1544V3D0JmmaoiJiaFbbr01VFVVdW7wzYMqu3fvzgFg7vwFAID5c1/E/LnndUlPdR3yxTANjCG1TVTtiUJgeE47AMCverXbPuaB9TvLKuoThCNxc3bK2lYJ8c36tUnUSwf1jz0mieDYUvG6lWIAeO2d3Xj4gR5LthecXjNrwbbNW7ZXJTcyCgydsXvGZ+S/+fKQX+cMvKAAeEPigWuvcU4IQdxfZynhMGct493CEVLGRmnBPj0TC6fl3jidMVb50OTSqyvW5+Xl/WT755s2XfL5rl27rvnu++/v21mwa+Lu3UUT9+7dO3Hf/gMTS0rLOv3UfAteXnjZtjvvXfM/nj3x/N8vrIX+j/ZHnvkSAPDB6oOXnPP+aZ9Fakp5xT+Lxd++PQUAePjpv14xflvyj/3fu8EeNWrU//Nb85kzZ0au4Fat+sl+Xbt2bf49YsSIZiv8V+Xtt99u/h2pJf28LFy48N/7GuBy8sADDzzxzjvvLJgzZ07qkSNH7ly+fPlr48ePn2qaJtd1PSErK+u1goKCSZZlmYqiuHNycvI2bNiQFh0d3b6hoUEfNmzYke3bt++srKwcnZeX9/qkSZMe4ZG7UvWee+5559SpU122bdt2raIovFOnTmXPPfdc83caCxYsiDp69Og0t9uthMNh5c4773xr5cqVrVNSUm6cO3fu4lGjRv1BCPHZhg0byprG3H777RNdLleKYRhIT0//pGfPnke3bt36QDgcFoyx6Lfeemv+zJkzc2fNmvU2gOjx48dPNk1z4bJly8TMmTNHtWzZMjh16tQvX3nlleQDBw7cs2zZskW33XbbEFVVi/v162fu3r17rKIook2bNscWLlz44ZXiqFwN6KFQaP7KlSvfNAzjLwBme71eXdO05+Lj4++JjY39MBwO+5cuXfqq1+t9XNf1zZWVlQcNw/h9VFRUJyK6oby8fI6UMk1RlBd79+4dzzmf//77789KTk42Dx06pDc0NPxnMBh8NhwOPyqlHHrh2sXFxR2klJ2ys7MX2bbdpqioKMc0zetramr+OGPGjGWGYTwTCoUu+u7BcZwZ11577RdpaWlrAoHAX++44w5mGMbzcXFxdw0fPnzd2rVrVdu2H549e/ahxYsXz2GMzTtw4IBBREYoFHqluLh4TeO+OwshXpkyZcp2n893m6Io7Q8ePHiz1+utzczM/COAOVeD41WBXl9fv7WwsDDT7/cfk1IqHo+HhBDe0tJSp6Ki4v6kpKQWjeVTnXNur1u3Tkop3Zqm1fp8vmFut3uhYRguIYRr0qRJYUVR9AkTJuSePXv27lAo1Nrr9R5u27ZtWefOna3jx49nX7i21+ttsG27x6effporpewTGxvr55zHqqr6nM/nq4qNjU11HCd48b0m08rLy8efPXt2msfjKfj+++81IYSrrKxM5OXljR81apRMTk72JyQkLK+qqhI1NTXOlClTlFmzZu0tKys7WVdXt+/xxx//Kjo62uX3+3cJId51uVz/aVmWjImJ4UQ0rKys7ImrZYyrAl0IMWzs2LFDKysrc4kotaqqihNRGyIaLYRYIIRoyqfTGGPfu1wuCCHGjBs3bqZpmqklJSXr3W53vhAiMTc3N6woSpwQIo9zfn1mZuZ2v9//XFlZ2YBDhw71TUpKuuHCtZOSkg4CyOacLyOiQd26ddsEYHEoFHr10UcfnQ4g3jCMgos2pyhZwWBwVjAYnJ6Wljb68OHDQcuy2gghRgcCgUWMMbJtO+fBBx+ck5OT85hlWYkjR44MVVRU9FUUZYiiKAODweCdPp9vkxBi4JIlS5bquh5n2/Y/EhMTl9u2PTYcDr9mGEbWL98G/iK/yC/yi/zvlP8DXh8lEQYro5IAAAAASUVORK5CYII=) XDMoD Data Analytics Framework"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/XDMoD-Data-Machine-Learning-JupyterHub.ipynb
+++ b/XDMoD-Data-Machine-Learning-JupyterHub.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# XDMoD Data Analytics Framework — Machine Learning Example for JupyterHub\n",
     "\n",
-    "Notebook v1.1.0 (2025-07-14)\n",
+    "Notebook v2.0 (2025-07-14)\n",
     "\n",
     "Compatible with XDMoD Data Analytics Framework v≥1.0.0 and <2.0.0\n",
     "\n",

--- a/XDMoD-Data-Raw-Data-JupyterHub.ipynb
+++ b/XDMoD-Data-Raw-Data-JupyterHub.ipynb
@@ -1,0 +1,731 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d570f686-8668-4553-95a3-fd44b90caa1b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# XDMoD Data Analytics Framework — Raw Data Example for JupyterHub\n",
+    "\n",
+    "Notebook v1.1.0 (2025-07-14)\n",
+    "\n",
+    "Compatible with XDMoD Data Analytics Framework v≥1.0.0 and <2.0.0\n",
+    "\n",
+    "© 2023–2024 University at Buffalo Center for Computational Research\n",
+    "\n",
+    "See the [xdmod-notebooks](https://github.com/ubccr/xdmod-notebooks) repository for licensing information."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26fd42a8-6176-4cce-992c-549ecb2a8ccb",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "The XDMoD Data Analytics Framework provides API access to the data in XDMoD via the [`xdmod_data` Python module](https://pypi.org/project/xdmod-data). This notebook provides an example showing how to use the `get_raw_data()` method to obtain and process individual records. In this example, you will obtain low-level job performance data from the `SUPREMM` realm in XDMoD."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1198bdc-eebf-4b9d-b432-ac32ecc3befb",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Configure notebook formatting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ed66cbd-806e-42e3-9127-4ccbe92128fb",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exceptions\n",
+    "Run the code below to simplify how Python exceptions are displayed in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2939223-09e1-4f1d-affc-426b2c937cb5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "def exception_handler(exception_type, exception, traceback):\n",
+    "    print(\"%s: %s\" % (exception_type.__name__, exception), file=sys.stderr)\n",
+    "get_ipython()._showtraceback = exception_handler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b11cca3e-fe75-4e26-bbbb-8745ce37770a",
+   "metadata": {},
+   "source": [
+    "### Tables\n",
+    "Run the code below to set up for displaying Pandas DataFrames as Markdown tables in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6e8d8eb-52ad-4619-891d-6f0c309e07f3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, Markdown\n",
+    "def display_df_md_table(df):\n",
+    "    return display(Markdown(df.replace('\\n', '<br/>', regex=True).to_markdown()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01fce24a-6a11-4df9-bfab-2eaf0ff4bb71",
+   "metadata": {},
+   "source": [
+    "### Plots\n",
+    "Run the code below to set up the external Plotly library to make plots using a custom XDMoD theme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b807989d-7bd6-46b7-b74e-0c8db8845376",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "import plotly.io as pio\n",
+    "import xdmod_data.themes\n",
+    "pio.templates.default = \"timeseries\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d46b0b77-c394-4dab-ad7b-ca7de10ceb24",
+   "metadata": {},
+   "source": [
+    "## Initialize the XDMoD Data Warehouse\n",
+    "Run the code below to prepare for getting data from the XDMoD data warehouse at the given URL. If no host is specified, the XDMOD_HOST environment variable is used to determine the host."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d968126f-d7f1-4a5b-acdf-c05fcb7b07a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from xdmod_data.warehouse import DataWarehouse\n",
+    "dw = DataWarehouse()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04a51b3c-3e0e-4fe7-9c6d-a0dffb092868",
+   "metadata": {},
+   "source": [
+    "## Get the raw data\n",
+    "\n",
+    "Use the `get_raw_data()` method to request raw data from XDMoD and load them into a Pandas DataFrame. For example, get three days' worth of low-level performance data of jobs run on ACCESS-allocated resources. Each of the parameters of the method will be explained later in this notebook. Use `with` to create a runtime context; this is also explained later in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "855abf68-3241-480c-8790-5fc6999bff7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_raw_data(\n",
+    "        duration=('2023-05-01', '2023-05-03'),\n",
+    "        realm='SUPREMM',\n",
+    "        show_progress=True,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cbb5424-cc5a-4267-a24e-df4946f30ab1",
+   "metadata": {},
+   "source": [
+    "Note that even just three days' worth of raw data constitutes over 100,000 rows. This is contrasted to the `get_data()` method, which aggregates data over a time period (day, week, month, etc.)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5d00abc-2e50-4d41-976c-3de4679b2dc6",
+   "metadata": {},
+   "source": [
+    "Inspect the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc856f49-fad3-409f-b05f-dbfe6e0a2e8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24b192d5-8594-4a83-8ef2-3e3e1e968d96",
+   "metadata": {},
+   "source": [
+    "Each row has many columns of data. View the names of all the columns:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7c8bf07-91b9-463d-b847-1b93a175dc24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(data.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fc5fea1-494c-4e48-a4e4-bd93398d398c",
+   "metadata": {},
+   "source": [
+    "Choose which columns to analyze. For example, compare wall time and total memory used in a scatter plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee619160-4025-4067-9d23-c2056071cd5b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = px.scatter(\n",
+    "    data,\n",
+    "    x='Wall Time',\n",
+    "    y='Total memory used',\n",
+    "    title='Total memory used vs. wall time of ACCESS jobs, 05/01/2023–05/03/2023',\n",
+    ")\n",
+    "plot.update_layout(hovermode=False) # Prevent hover interactions causing lag due to so many points\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cce8d96-f176-49e2-a717-3fd2679bd0a4",
+   "metadata": {},
+   "source": [
+    "Wall time is measured in seconds, and total memory used is measured in bytes. Convert these to hours and gigabytes, respectively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "922470d3-a1b4-4c93-b4ce-da0b4047eb50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data['Wall Time (hours)'] = data['Wall Time'].astype(float) / 3600\n",
+    "data['Total memory used (GB)'] = data['Total memory used'].astype(float) / 1e9"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a104434f-8356-413f-9551-435832254063",
+   "metadata": {},
+   "source": [
+    "Plot the data again:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee587796-8c9d-4519-b6d9-d156fa812834",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = px.scatter(\n",
+    "    data,\n",
+    "    x='Wall Time (hours)',\n",
+    "    y='Total memory used (GB)',\n",
+    "    title='Total memory used vs. wall time of ACCESS jobs, 05/01/2023–05/03/2023',\n",
+    ")\n",
+    "plot.update_layout(hovermode=False) # Prevent hover interactions causing lag due to so many points\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fa6c9d-248a-4292-aa60-e19b94d191e4",
+   "metadata": {},
+   "source": [
+    "Looking at the graph, many jobs ran for under 48 hours, while some ran for longer. Many jobs used less than 500 GB, while some used more. It is important to note that this data comes from multiple different computing resources, each of which has its own architecture and scheduling policies. Color-code the graph by the resource:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85211719-dacc-4435-90f0-062196e2bde1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = px.scatter(\n",
+    "    data,\n",
+    "    x='Wall Time (hours)',\n",
+    "    y='Total memory used (GB)',\n",
+    "    title='Total memory used vs. wall time of ACCESS jobs by resource, 05/01/2023–05/03/2023',\n",
+    "    color='Resource',\n",
+    ")\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cdbfa38-c8d7-4a50-974e-6376c549f68c",
+   "metadata": {},
+   "source": [
+    "One can begin to see from this graph that the different resources are used differently. Filter by a specific resource, e.g., PSC Bridges-2 Regular Memory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d8c0690-8c45-497f-9435-37a083874c4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = data[data['Resource'] == 'bridges2-rm.psc.xsede.org']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c86e389-5b4c-4810-9b69-88fb4902f707",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = px.scatter(\n",
+    "    data,\n",
+    "    x='Wall Time (hours)',\n",
+    "    y='Total memory used (GB)',\n",
+    "    title='Total memory used vs. wall time of jobs on Bridges-2 RM, 05/01/2023–05/03/2023',\n",
+    ")\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46b8da5d-5ad3-48f1-a607-06d2571d2d0b",
+   "metadata": {},
+   "source": [
+    "A better approach, if you know you only need to analyze the data from specific resource(s), is to modify the original call to `get_raw_data()` to include a `filters` parameter (this parameter will be explained in detail later in this notebook):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33cdb89c-3a99-46cf-8562-8762d86a2354",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_raw_data(\n",
+    "        duration=('2023-05-01', '2023-05-03'),\n",
+    "        realm='SUPREMM',\n",
+    "        filters={\n",
+    "            'Resource': 'Bridges 2 RM',\n",
+    "        },\n",
+    "        show_progress=True,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb160d5f-55c7-4492-882e-6a77df3358f4",
+   "metadata": {},
+   "source": [
+    "This requests fewer rows, taking less time to transfer and less memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2d76d12-7e6b-40ca-9896-fb84e044863a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data['Wall Time (hours)'] = data['Wall Time'].astype(float) / 3600\n",
+    "data['Total memory used (GB)'] = data['Total memory used'].astype(float) / 1e9"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42930456-fb15-47b1-9580-5b16dc8d02d2",
+   "metadata": {},
+   "source": [
+    "With the data from the specific resource, you can further drill down by field of science:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ff270b6-98c3-4c35-bfee-b247bb777c0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = px.scatter(\n",
+    "    data,\n",
+    "    x='Wall Time (hours)',\n",
+    "    y='Total memory used (GB)',\n",
+    "    title='Total memory used vs. wall time of jobs on Bridges-2 RM by field of science, 05/01/2023–05/03/2023',\n",
+    "    color='Field of Science',\n",
+    ")\n",
+    "plot.update_layout(height=550) # Make sure the plot can accommodate a larger legend\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f53a1a9-970b-4ba6-abb4-5d6b07075ad1",
+   "metadata": {},
+   "source": [
+    "If you want to analyze the data for a specific field of science, you can add it to the list of `filters` in the original call to `get_raw_data()`. If you do not need to drill down any further, you can also restrict the requested fields of data to only those you need (e.g., wall time and total memory used) by using the `fields` parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09eab927-b20d-4f9a-8c20-ce48b8ef9ad6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_raw_data(\n",
+    "        duration=('2023-05-01', '2023-05-03'),\n",
+    "        realm='SUPREMM',\n",
+    "        fields=(\n",
+    "            'Wall Time',\n",
+    "            'Total memory used',\n",
+    "        ),\n",
+    "        filters={\n",
+    "            'Resource': 'Bridges 2 RM',\n",
+    "            'Field of Science': 'Chemical Engineering',\n",
+    "        },\n",
+    "        show_progress=True,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16f9bbbe-9b4c-4755-91e1-3e896559b0cb",
+   "metadata": {},
+   "source": [
+    "This greatly reduces the amount of data that needs to be requested, taking up less time and memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da4db027-22e4-4cc7-8fd4-d48a6fab241e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data['Wall Time (hours)'] = data['Wall Time'].astype(float) / 3600\n",
+    "data['Total memory used (GB)'] = data['Total memory used'].astype(float) / 1e9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38d5be4b-55f6-48ee-9047-1997ccb93270",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = px.scatter(\n",
+    "    data,\n",
+    "    x='Wall Time (hours)',\n",
+    "    y='Total memory used (GB)',\n",
+    "    title='Total memory used vs. wall time of chemical engineering jobs on Bridges-2 RM, 05/01/2023–05/03/2023',\n",
+    ")\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c8578b2-85fb-4ee0-8b32-6c62890b0fa5",
+   "metadata": {},
+   "source": [
+    "## Details of the `get_raw_data()` method\n",
+    "Now that you have seen examples of using the `get_raw_data()` method, read below for more details on how it works."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5182c27-a127-4309-8db3-95a96ff25ffe",
+   "metadata": {},
+   "source": [
+    "### Wrap data warehouse calls in a runtime context\n",
+    "XDMoD data is accessed over a network connection, which involves establishing connections and creating temporary resources. To ensure these connections and resources are cleaned up properly in spite of any runtime errors, you should call data warehouse methods within a **runtime context** by using Python's `with` statement to wrap the execution of XDMoD queries, store the result, and execute any long running calculations outside of the runtime context, as in the template below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d921f294-edd2-44d9-99c2-d607c61f9690",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    # XDMoD queries would go here\n",
+    "    pass\n",
+    "# Data processing would go here\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "775343e2-6d0f-407e-8a19-761640aabad3",
+   "metadata": {},
+   "source": [
+    "### Parameters\n",
+    "The `get_raw_data()` method has a number of parameters explained in detail below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4aee97bf-074b-49c7-8af3-d0961bf84d65",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Duration\n",
+    "The **duration** provides the time constraints of the data to be fetched from the XDMoD data warehouse.\n",
+    "\n",
+    "As already seen, you can specify the duration as start and end dates. These are both inclusive, so if you only want one day of data, use the same date for start and end:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1abfa58b-1189-488e-b3ef-b8150f915c01",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_raw_data(\n",
+    "        duration=('2023-05-01', '2023-05-01'),\n",
+    "        realm='SUPREMM'\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd15134-f0f9-4aab-b59b-5df502255bea",
+   "metadata": {},
+   "source": [
+    "You can instead specify the duration using a special string value; a list of the valid values can be obtained by calling the `get_durations()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cb25776-3d50-424d-b46e-be49c7f15d38",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    durations = dw.get_durations()\n",
+    "display(durations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6628539-6c5c-4a8d-b699-f0825f3ff5bd",
+   "metadata": {},
+   "source": [
+    "### Realm\n",
+    "A **realm** is a category of data in the XDMoD data warehouse. You can use the `describe_raw_realms()` method to get a DataFrame containing the list of realms for which raw data is available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eae9473a-374d-4b72-8b63-09ce6c278749",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    raw_realms = dw.describe_raw_realms()\n",
+    "display_df_md_table(raw_realms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8721f4d4-94ed-46a7-977e-4ef21f0a10e3",
+   "metadata": {},
+   "source": [
+    "### Fields\n",
+    "A **field** is a measurement for which raw data exists in a given realm. You can use the `describe_raw_fields(realm)` method to get a DataFrame containing the list of valid fields in the given realm. The realm must be passed in as a string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b48ebdf9-db62-49c6-b16a-04e8eefab7f2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    raw_fields = dw.describe_raw_fields('SUPREMM')\n",
+    "display_df_md_table(raw_fields)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec83ade8-b969-435c-be02-5672d196fa7e",
+   "metadata": {},
+   "source": [
+    "### Filters\n",
+    "**Filters** allow you to include only data that have certain values for given **dimensions**, which are groupings of data. You can use the `describe_dimensions(realm)` method to get a DataFrame containing the list of valid dimensions in the given realm. The realm must be passed in as a string and can be either the ID or the label of the realm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b427bb00-57c8-4874-9c6c-e83fee258092",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    dimensions = dw.describe_dimensions('SUPREMM')\n",
+    "display_df_md_table(dimensions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9939e980-12b6-4b57-aeb1-8ed4ac195cda",
+   "metadata": {},
+   "source": [
+    "You can use the `get_filter_values(realm, dimension)` method to get a DataFrame containing the list of valid filter values for the given dimension in the given realm. The realm and dimension must be passed in as strings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e94c8fe1-212e-4844-8fe8-1ae87a013fb0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    filter_values = dw.get_filter_values('SUPREMM', 'Resource') # 'resource' also works\n",
+    "display_df_md_table(filter_values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d09b155a-bc9c-4d27-be15-3762b5839ebb",
+   "metadata": {},
+   "source": [
+    "For methods in the API that take filters as arguments, you must specify the filters as a dictionary in which the keys are dimensions (labels or IDs) and the values are string filter values (labels or IDs) or sequences of string filter values. For example, to return only data for which the field of science is Materials Engineering and the resource is either Bridges-2 RM or TACC Stampede2:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0995fab0-3b00-4124-b7fb-b3a9cc3ba1a4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with dw:\n",
+    "    data = dw.get_raw_data(\n",
+    "        duration=('2021-05-01', '2021-05-01'),\n",
+    "        realm='SUPREMM',\n",
+    "        filters={\n",
+    "            'Field of Science': 'Materials Engineering', # 'fieldofscience': '177' also works\n",
+    "            'Resource': ( # 'resource' also works\n",
+    "                'Bridges 2 RM', # '2900' also works\n",
+    "                'STAMPEDE2 TACC', # '2825' also works\n",
+    "            ),\n",
+    "        },\n",
+    "        show_progress=True\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfbc4c64-d9a1-4224-8948-6a10edf775a2",
+   "metadata": {},
+   "source": [
+    "### Show progress\n",
+    "Set the `show_progress` parameter to `True` to periodically print how many rows have been gotten so far. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35ae0825-73d3-4bc7-9fe4-d5e4ec10be0a",
+   "metadata": {},
+   "source": [
+    "## Additional Examples\n",
+    "For additional examples, please see the [xdmod-notebooks repository](https://github.com/ubccr/xdmod-notebooks)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02cf2b59-7eeb-4f1d-bee4-797af7d2d643",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "![XDMoD](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAF0AAAAgCAYAAABwzXTcAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfaCR0QJxALRnmrAAAWJUlEQVRo3u16aXRVVbbut3Z7mjQngYRAGkIgiCChEYFCgiBRChBBryJQBUJZWkQuitcWRUFQaURKS1FUsApBrxEQEJGy1FKgiCIEEjpD36QjhIScnJxzsvdea8334yQB6oJC1Rvv/bjOMTLGyV7dXN9e85vN2sAv8v9ftm7detVj3njjjase8+GqT/7XYswu9fDw4cPXrl69ekdRUZHQdR2MRbp5vd6C7OzsX48bN85u6vv5559D0zTlhx070stKS01d1wGA6gL1LDktHUREmqpCUVUoigKPx0O6YdQriurouub4Yn3WmLtGhX5KyTeXbY9+bMaueNWjwuvSEKzn6Ns7Tn656u6S194twMP3X9/cl4iUNl3/3JYLkkSEhgYJn8+Qf3y+W/ndI3uIfxWoASM+iD16IuiLitIpOkpDVbWFjhmxZBoEX4wmO2XGOc/818Aaxhj/4u+HMOTmjpedS7vUw8zMzB/Xrl276PDhw88Gg0EADIrCcO7cuUGnT5+eBODt9evXIyoqCoMHD8aKFSvGVFZWrhBCKEQAY0Cgvr75ZRFjYIyBKQpsxyEpyVZUtcFxnIBlWTVvvPPezqSEln+8647b9320+hOMuevOi/Q5fqr2ibCNGYbGwB0JzoEDh0IgIi9j7KIXtmtP2ZCqGudzTVMAAFIyhOsFP1PV0B3A/n8V9HCDnHWuDtPqghxqlQAXhMK9ATAGaCrkP74L1K397KM9R09ULGmf3vq/f2ou5VIPN2/eDMuyns/IyPgRADRNhaaq0A0Du3fvXlJZWdli5MiRGDx4MIhIO3To0Hu2ZSmapkNVVaiqBikFhJAQnENwASEEpBAQQjAuuCk4jxVCpAguutqW9buSsoq976348PF/BhwATp+xYkkCQgAOJxAYyk4GsXTlrpH/3HfV+oN/4AEOzgHOASkBbkuq8dtR/w4lCElk2UC4AagPEYUbCDV1AtV+jsoarpRW2bEFe/3Z7Tuv+XDR4u/mExFGjPvwykG/6aabMGbMGNG+fftZPp8PjDFSVBWqopKqKpg3b/4iImIAMHv27HVVZ8+aum6QpqnQdJU0TYWUBMEdcCEgBSfBBQkhIQQH5xyy0SSEEAxEAAj+usCCt5e9/0EwHFa/+mbLedCrGqLA/okJVQVrPjvR+cJHRKSu3lh+PcyLDZgD2r4fa1z/Dugkz1OxkMQSW6iyXaoevibDLaO8CniIM81UofoMev6lvU+s+XTfkxs+HIfjJ89eGehNMnbs2I87dOiwWdM0pmkaqZrKDMNEQ0N43Pz581NeeOGFX505c+YWQ9dJ01Sm6ToZusFAFAAQ4EJETrqUjAvONFUZzaTsER/tHXa6vGRZZXmZxRQlYgVSAkQIN4THfbLus/tyBg1o1qOq2vFerClBNVRUnOY3v//xXhUAivZXYe3nB7pWlDXEa4YCIroAMGJ19VK/3D7r6urx6pJtbN3Gfaxp3NKVhRc7P3Z+Qjpn4fWX+qw48sNEz4Ft49Xaw/ddN2xIqwAPccbAWECAxk3On0dEndu1bXllnA4A+fn56NevHwYPHjyqtLT0ZCgcjlEYg6IoAKAFg8GV9fX1uq7rRsQKFCiqyizLQkpq6l2nSspe59yJBiHC7ZqGs9XVRX9a9PIhAIUANj04OfeVH2uq8zp27tIVIuLjFEXBudrat0+eKlndNi21hoiUzL4fxEFhF/l/xgDHdvr+7qGNyP+hDN26JOCOe9e1dyR5Iu0RA2IM4ATU1NrRTaP3HKhCVucEAMCzc7/9TfaIT3sHwzLNMFX7xVeLDm/6+uC3Qwdf89XFr/liS7Mc7gKAHbtLwRjbT0Sp3bP/u3LfsaCpKIzZAY7R93/+FBFNYP9kpZc96f369cOmTZvg8/lqdV2fxwDSdB2qqsEwDNQFAtlgrK+u69A1DZqmQVEUeD2eRVu3bNkmSLgF5xCCQwhO3HHQvVuWu2n+3/72Xry55K0fuR2asH9PUUjTdZJSQEpJtu3g75u3zgGAwn2lpsORoKoKASApCdR4HI+WhpVVy+7q0693cmQzzLydS2o83NR8OoUE0pLjkpvWzuqcACJqMfyeNZVz5h9Yuae4/qHjJeFRxUcCo3cW1T89dPQ3X475/aeriEgtK6+7JOpN5/6GHik4dy4EAP4Wie63hB05PFq0jqPFgeyColNRV0UvQ4cORUZGBl5++eVFnPMShTHoukaapsEwDGYYBlN1HZqmweVyU52/rtLlcr3UKqmVQRLgjfzNOWecO+jRLavZslauXA4AWL58ReGZitJddX4/k5IgpWSMAf66wND9B4o9hfsqDSZlHGNgnEuWme62or0qAYBVz7E5/8SLTXP6/aGRAIMQxDq0ddm+aA1EBCIgGLLTAMCV8hIK9lXrN9768Q8bN1Umal6dSBJM4zyYmqnSJxvK77rv4b8tT24T04g5XRanuDgPGGPo2yP6MBPnacgftNKXrjxgXhXoEVCWgzFm3XLLLcP8fj90XWdaI9C6psHQNBiGSefO1bDrrusy5dlnn60GAEkSwolELpwLcM5hWdYl1+jYsePq0xXlICkhhYCUgoQQUTt2FcaVlAU1ABFqcAjXdHCfTU/2nGg82viu4Gx/ACjcW9n2+8KaWMYAIkJ2n8R8lysCIkmgdYK7HQA0lD6NoqKS9/J/qM7QonTilmQ9sqLsJfP79p31aNbELh29jIiYUFW8t/Twb7ZuP/YQAAhBP+tsU1M9lXQBlZwLcuworFGuGvR7770Xq1atwtixY/cTsFhKQjOl6Do0TYeiMMYYW5ebm7vm9ddfB8BAUsDhHFzw5rCRpLzkGi7T3BWsD0BIASEFpJBMSqmfq611nzhVp3EuvBekcsEGh76VkqCaCm0vqNV27j7Va8t3Jx+qr3HAGCOXqSAxIWa2x62xJl6vOBPo0hjhxDz5QsFvmUsjImIJCTp2fTWuzYQxXbc/91jf5cnJnt+BGrkkSqfxD26b1OiN2c9hldI6JnChw7VsidNnLHbVoAOA2+1ucl+xLpcJXdMagddhGDpMlwuWZQ0AgKlTp0IBICWB8wjgXET+JF36tFi2Q5JkUxwfAV8IJoRgDZZUScI8H0Ww4C03JRRKS0TcKSe8u3Jf9savTg5HxMmzFtGakzMwvkgK3hxphsO8DQB88EnRuKpSC6oaaeiQ6q3+1ZDl1cWHarA5vwwT7m53WAezI/mJAjss0jd88WMCmPKzR33Ar5JtNFtEhNb4JSzkZ0GfN28ebrvtNsycOXOoEPy3brcbmqZHQNd1aJoBQ9epQ2Zm/NSpU/8CAExlEXrhDjh3IsA7zkVh3EVxNOfdDMNsjOkFhBAkhXCiozzhkrKQGrYbLUQSWiW4aiaO6fhdYzRD0BSUlFs53xfUJSumQlISVEM7PLh/p5rWrTycJAEM8AecWADY9OWprlAvsBtVKb5/Qld06hiPm/olo1dWYik0ZjeqymwhY9Z8dsyjKPhZ0AsKTxtQWXOEpWkMMVEaXTXoTz31FL7Lz0/Kz8/Py8rqBlXTSNd16IYB0zSh6xo0XWdej5fS2rYd+8i0ad05F5BCwnGcRj6PJEl0GRM9cuTIXb64eHCHQwoOKQQjokCv7p2r2qe3aGE51OzlOrSLq7y+W9udXTp7Le5IpmoMBXtqc0IN0qsoDLJB4LrOnv0A4IsxTjftOBSOvLhdRVUuGFqz0wwEeX1peaBZl5gYj2CKAjRi3GAJZfO2MrUxVP5JOXayNg4XJFE+r4aeWb6rA33JkiUAgLnz5s0eMOCmaFVToWs6M0wDAHMC9QGYpkmGbkDVVJbQMsGIi49flpCQaEspKUIvEeAF55Dy/Ppz584FADz+2GPXub1RvV0uF0UyWCLLthEbE73u+uv7WNHRahfLks1ZqBTOKQB46L7OmxDmYIxRVbVjSEmMGpHMvbfLZwDgcaunGSKcXlVtgYj0Fi08Ao16MAbERutG546+Zr1OlNQoEYuMYKdrCq5pH0eXs9IL5YfCc8kX9KL4aKPmzhHpzhWD/s0332Dy5Mn4+OOPe7ZqlXR/VHQUVFWFbkRoJTEx4e5TJ08WGYbBNF2DoRswDIPS2rbtqWnaDClEmDtOxJlyB9xx4HK5mj3p9OnTUVpyIvrIsRMfprVt52kIh5mQEpw7TFNVTJl8/wwA8EWbPTmn5ri4y7WJRwGgY4eEWZ4WBogIihJJhgSXrFsPH0YM6fQ+AERHucubQKgPE6qrazvkZLcpg3W+2GhbImX3vtrz/zuyJTlSa/IF0aYafOgPWQ1CyMuCXVVdDwAoL+MjFDPCL9wW0L3a9tEjsgJXDPqgQYNARPpHH330dZcuXaCqKgzDIEM34Ha5tiS2StxIRI9WVJSLqKhoMkwDuq6z+Lh4Sk5JfcrhPNNxGvmccxAIGzduzJgwcVLmlClTe/4hN/fhRx59qqZV69ZdhRDUGOUQdxwkJiTc11Q9PF0VuCZi6QTDo8LQtUIAGNQ/rahzh6j6SKgUqd2AEwb3T9retIdg2C6NZIMMVoPE5vyTmVPv7/5XGKw5wXIcnvHSjIHN+/70i5PtSEojUqEkIl0pGzq4YzUksQvSU5i60vwWWsYL1zvvF/3mH9vPDFQi2hALc/bGvF55jDF5RaB/8803ICJMGD9hbq8bbvC53C4yDAONNIKUlJTHhtxyK3/33Xe/rqw8/XU4HGKmaZJhmmCMsfT0dPS/8Ualvr6+OYJxHAd79uz9qCHc8OM5f21BfTD0alR0jMY5J845E1xQuCHM4uN8K2779bA/r1qztrE0i7SmYx7tUdA2xXOsSU9dN76IMEEEWJdXhaYbTze1m6ZZzlhjsy1QF5Q9WsTHbh89KrVahAQDgD3FAXXB6/lvNo3Zt7/uSR4hcJJ+m90+pE0+Y8xmKjvPHF4Ni/98eGD3gSs/7ZK9YlOHGzbseHzmjpX+kCQwBuG32TPPdN/ap2fG8iuqMq5fvx6DBg3CokWL0tokt3k4MTGRVFVlhm5A0zTWOinpT7feeuuOb7+NVAFfe+1Pd5SVlnLDMJmh6zBdJjRNw/Dhw5GWmoKGcAhNJ15IoTrcUR2HkxSNDpY7TAgOx7EdX0zsq89Mf3LCW++8RXf/xx0AgIrKYFJT3BflVdGpY3JNk65pKdpX4OcdRVK8YTt2aP9Xm0sAADW14dJm/8cYfthZ0RUAJo69rn+LhEgKqmgqPfH07twOvZdTu15/ob99XdlLURhxW7A+A1rai+fnTIq4k/MHXXNr9O22s60L99WP2F8c+vXx0tB1QYtIUcC4I9iQnNYnX3i6/4C/bz12ZaXdkSNHgohcFRUVO9tlZGiqojLDMGAYBjwez8mExFZPAsDAgQPwxRdfgDEWSkxMmOg4NkyXiwzDhGEYMEwT9/3+92QYBhzbjkQyTiSEdGybCSFARELX9KMu03wtMaFln7kvzn7kyenPYEB2/2Z9KiqtBDgSwpZoyjs2fnUcADBtctZu6RBxS4KHBQSUvU9N6+XPuSm1iZ+riBO4LYCwQH1YtgWAYTnpxfeMysht4VPBQ4KpUQaOnLBw/JQNxaUSD3J2baa3+sXpfbs16eE4UhchAR7i4JZkIAACgCBIS4LXOyyphY57787Iy/tgQB8AuDk748pvjtasWeNOT2831G26HCgMqqqCgSG+RfzpPr1vaGjqN2TIEGzZsgUtW7ZcfejgwadM0+jCmEKaFrnIaNUqiT0zY8bSF1544V3D0JmmaoiJiaFbbr01VFVVdW7wzYMqu3fvzgFg7vwFAID5c1/E/LnndUlPdR3yxTANjCG1TVTtiUJgeE47AMCverXbPuaB9TvLKuoThCNxc3bK2lYJ8c36tUnUSwf1jz0mieDYUvG6lWIAeO2d3Xj4gR5LthecXjNrwbbNW7ZXJTcyCgydsXvGZ+S/+fKQX+cMvKAAeEPigWuvcU4IQdxfZynhMGct493CEVLGRmnBPj0TC6fl3jidMVb50OTSqyvW5+Xl/WT755s2XfL5rl27rvnu++/v21mwa+Lu3UUT9+7dO3Hf/gMTS0rLOv3UfAteXnjZtjvvXfM/nj3x/N8vrIX+j/ZHnvkSAPDB6oOXnPP+aZ9Fakp5xT+Lxd++PQUAePjpv14xflvyj/3fu8EeNWrU//Nb85kzZ0au4Fat+sl+Xbt2bf49YsSIZiv8V+Xtt99u/h2pJf28LFy48N/7GuBy8sADDzzxzjvvLJgzZ07qkSNH7ly+fPlr48ePn2qaJtd1PSErK+u1goKCSZZlmYqiuHNycvI2bNiQFh0d3b6hoUEfNmzYke3bt++srKwcnZeX9/qkSZMe4ZG7UvWee+5559SpU122bdt2raIovFOnTmXPPfdc83caCxYsiDp69Og0t9uthMNh5c4773xr5cqVrVNSUm6cO3fu4lGjRv1BCPHZhg0byprG3H777RNdLleKYRhIT0//pGfPnke3bt36QDgcFoyx6Lfeemv+zJkzc2fNmvU2gOjx48dPNk1z4bJly8TMmTNHtWzZMjh16tQvX3nlleQDBw7cs2zZskW33XbbEFVVi/v162fu3r17rKIook2bNscWLlz44ZXiqFwN6KFQaP7KlSvfNAzjLwBme71eXdO05+Lj4++JjY39MBwO+5cuXfqq1+t9XNf1zZWVlQcNw/h9VFRUJyK6oby8fI6UMk1RlBd79+4dzzmf//77789KTk42Dx06pDc0NPxnMBh8NhwOPyqlHHrh2sXFxR2klJ2ys7MX2bbdpqioKMc0zetramr+OGPGjGWGYTwTCoUu+u7BcZwZ11577RdpaWlrAoHAX++44w5mGMbzcXFxdw0fPnzd2rVrVdu2H549e/ahxYsXz2GMzTtw4IBBREYoFHqluLh4TeO+OwshXpkyZcp2n893m6Io7Q8ePHiz1+utzczM/COAOVeD41WBXl9fv7WwsDDT7/cfk1IqHo+HhBDe0tJSp6Ki4v6kpKQWjeVTnXNur1u3Tkop3Zqm1fp8vmFut3uhYRguIYRr0qRJYUVR9AkTJuSePXv27lAo1Nrr9R5u27ZtWefOna3jx49nX7i21+ttsG27x6effporpewTGxvr55zHqqr6nM/nq4qNjU11HCd48b0m08rLy8efPXt2msfjKfj+++81IYSrrKxM5OXljR81apRMTk72JyQkLK+qqhI1NTXOlClTlFmzZu0tKys7WVdXt+/xxx//Kjo62uX3+3cJId51uVz/aVmWjImJ4UQ0rKys7ImrZYyrAl0IMWzs2LFDKysrc4kotaqqihNRGyIaLYRYIIRoyqfTGGPfu1wuCCHGjBs3bqZpmqklJSXr3W53vhAiMTc3N6woSpwQIo9zfn1mZuZ2v9//XFlZ2YBDhw71TUpKuuHCtZOSkg4CyOacLyOiQd26ddsEYHEoFHr10UcfnQ4g3jCMgos2pyhZwWBwVjAYnJ6Wljb68OHDQcuy2gghRgcCgUWMMbJtO+fBBx+ck5OT85hlWYkjR44MVVRU9FUUZYiiKAODweCdPp9vkxBi4JIlS5bquh5n2/Y/EhMTl9u2PTYcDr9mGEbWL98G/iK/yC/yi/zvlP8DXh8lEQYro5IAAAAASUVORK5CYII=) XDMoD Data Analytics Framework"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/XDMoD-Data-Raw-Data-JupyterHub.ipynb
+++ b/XDMoD-Data-Raw-Data-JupyterHub.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# XDMoD Data Analytics Framework — Raw Data Example for JupyterHub\n",
     "\n",
-    "Notebook v1.1.0 (2025-07-14)\n",
+    "Notebook v2.0 (2025-07-14)\n",
     "\n",
     "Compatible with XDMoD Data Analytics Framework v≥1.0.0 and <2.0.0\n",
     "\n",


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->
This adds new example notebook for running in an instance of JupyterHub. The v1.1.0 changes can be viewed on https://xdmod-dev.ccr.xdmod.org/jupyter

## Description
<!--- Describe your changes in detail -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
There are certain cells in the example notebooks that are not necessary when running in JupyterHub. These cells include generating and setting up an API token and specifying an XDMoD host. For each notebook in this repository, a corresponding notebook has been added with these changes.

Here is a diff of the changes for the First Example notebook. The same changes have been applied for each notebook.
```
$ diff XDMoD-Data-First-Example.ipynb XDMoD-Data-First-Example-JupyterHub.ipynb
10c10
<     "# XDMoD Data Analytics Framework — First Example\n",
---
>     "# XDMoD Data Analytics Framework — First Example for JupyterHub\n",
12c12
<     "Notebook v2.0 (2024-09-27)\n",
---
>     "Notebook v2.0 (2025-07-14)\n",
33,61d32
<    "id": "84713a67-80c4-4803-8a45-0decdb65b500",
<    "metadata": {},
<    "source": [
<     "## Install/upgrade the required modules\n",
<     "\n",
<     "Run the code below to install/upgrade the modules needed to run this notebook."
<    ]
<   },
<   {
<    "cell_type": "code",
<    "execution_count": null,
<    "id": "43521c0d-ca9e-47cd-ba5a-c1f9d0b83290",
<    "metadata": {},
<    "outputs": [],
<    "source": [
<     "import sys\n",
<     "! {sys.executable} -m pip install --upgrade 'xdmod-data>=1.0.0,<2.0.0' python-dotenv tabulate"
<    ]
<   },
<   {
<    "cell_type": "markdown",
<    "id": "56c7d25d-241b-4c65-a77b-7eca37386714",
<    "metadata": {},
<    "source": [
<     "If running that code caused a new version of Plotly to be installed/upgraded, you may need to refresh your browser window for plots to appear correctly."
<    ]
<   },
<   {
<    "cell_type": "markdown",
146,225d116
<    "id": "035a27ba-a47b-4fe6-a7ea-b73e5f5a308a",
<    "metadata": {},
<    "source": [
<     "## Create an environment file\n",
<     "\n",
<     "The `xdmod-data.env` file will store your XDMoD API token.\n",
<     "\n",
<     "Run the code below to create the file in your home directory (if it does not already exist) and allow only you to read and write to it."
<    ]
<   },
<   {
<    "cell_type": "code",
<    "execution_count": null,
<    "id": "7d216a32-11c6-4ae4-98e9-1b2c19d442d2",
<    "metadata": {
<     "tags": []
<    },
<    "outputs": [],
<    "source": [
<     "from pathlib import Path\n",
<     "from os.path import expanduser\n",
<     "xdmod_data_env_path = Path(expanduser('~/xdmod-data.env'))\n",
<     "try:\n",
<     "    with open(xdmod_data_env_path):\n",
<     "        pass\n",
<     "except FileNotFoundError:\n",
<     "    with open(xdmod_data_env_path, 'w') as xdmod_data_env_file:\n",
<     "        xdmod_data_env_file.write('XDMOD_API_TOKEN=')\n",
<     "    xdmod_data_env_path.chmod(0o600)"
<    ]
<   },
<   {
<    "cell_type": "markdown",
<    "id": "67311e00-9fd8-4b1c-80cc-44b0d4b18a7f",
<    "metadata": {},
<    "source": [
<     "## Obtain an API token\n",
<     "\n",
<     "Follow [these instructions](https://github.com/ubccr/xdmod-data#api-token-access) to obtain an API token."
<    ]
<   },
<   {
<    "cell_type": "markdown",
<    "id": "ae55bfed-eedc-4a72-88d9-510fe271ed36",
<    "metadata": {},
<    "source": [
<     "## Store your API token in the environment file\n",
<     "\n",
<     "Open the `xdmod-data.env` file and paste your token after `XDMOD_API_TOKEN=`.\n",
<     "\n",
<     "Save the file."
<    ]
<   },
<   {
<    "cell_type": "markdown",
<    "id": "02193bb2-1b80-4b9d-8733-ad292a877ccf",
<    "metadata": {
<     "tags": []
<    },
<    "source": [
<     "## Load your XDMoD API token into the environment\n",
<     "\n",
<     "Run the code below to load the contents of the `xdmod-data.env` file into the environment. It will print `True` if it successfully loaded the file."
<    ]
<   },
<   {
<    "cell_type": "code",
<    "execution_count": null,
<    "id": "d5eefbd5-8eab-4ac2-87fe-2c6271c7b9cd",
<    "metadata": {
<     "tags": []
<    },
<    "outputs": [],
<    "source": [
<     "from dotenv import load_dotenv\n",
<     "load_dotenv(xdmod_data_env_path, override=True)"
<    ]
<   },
<   {
<    "cell_type": "markdown",
231c122
<     "Run the code below to prepare for getting data from the XDMoD data warehouse at the given URL."
---
>     "Run the code below to prepare for getting data from the XDMoD data warehouse at the given URL. If no host is specified, the XDMOD_HOST environment variable is used to determine the host."
242c133
<     "dw = DataWarehouse('https://xdmod.access-ci.org')"
---
>     "dw = DataWarehouse()"
734c625
<    "version": "3.11.4"
---
>    "version": "3.12.11"`
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- For each notebook changed:
    - [x] The minor version number at the top of the notebook has been incremented (e.g., 1.0 becomes 1.1).
    - [x] The compatibility with the XDMoD Data Analytics Framework is correctly documented at the top of the notebook.
    - [ ] The copyright year is (years are) correct at the top of the notebook.
    - [ ] All cells in the notebook have been run and confirmed they work.
- [ ] `CHANGELOG.md` has been updated.
- [x] The appropriate labels have been added to the pull request.
- [x] The milestone is set correctly on the pull request.
- [x] The changes in this PR have been ported/backported to other branches as needed.
